### PR TITLE
feat(admin): add separate Edit/Delete button components and role-based rendering for notices and meetings

### DIFF
--- a/app/protected/Admin/Notices/components/DeleteButtonMeeting.tsx
+++ b/app/protected/Admin/Notices/components/DeleteButtonMeeting.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { Button } from '@mantine/core';
+import { Trash } from 'lucide-react';
+
+export default function DeleteButtonMeeting({ id }: { id: string }) {
+  return (
+    <Button
+      variant="light"
+      color="red"
+      radius="xl"
+      size="compact-sm"
+      leftSection={<Trash size={14} />}
+    >
+      Delete
+    </Button>
+  );
+}

--- a/app/protected/Admin/Notices/components/DeleteButtonNotice.tsx
+++ b/app/protected/Admin/Notices/components/DeleteButtonNotice.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { Button } from '@mantine/core';
+import { Trash } from 'lucide-react';
+
+export default function DeleteButtonNotice({ id }: { id: string }) {
+  return (
+    <Button
+      variant="light"
+      color="red"
+      radius="xl"
+      size="compact-sm"
+      leftSection={<Trash size={14} />}
+    >
+      Delete
+    </Button>
+  );
+}

--- a/app/protected/Admin/Notices/components/EditButtonMeeting.tsx
+++ b/app/protected/Admin/Notices/components/EditButtonMeeting.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { Button } from '@mantine/core';
+import { Pencil } from 'lucide-react';
+
+export default function EditButtonMeeting({ id }: { id: string }) {
+  return (
+    <form>
+      <Button
+        variant="light"
+        color="blue"
+        radius="xl"
+        size="compact-sm"
+        leftSection={<Pencil size={14} />}
+      >
+        Edit
+      </Button>
+    </form>
+  );
+}

--- a/app/protected/Admin/Notices/components/EditButtonNotice.tsx
+++ b/app/protected/Admin/Notices/components/EditButtonNotice.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { Button } from '@mantine/core';
+import { Pencil } from 'lucide-react';
+
+export default function EditButtonNotice({ id }: { id: string }) {
+  return (
+    <form>
+      <Button
+        variant="light"
+        color="blue"
+        radius="xl"
+        size="compact-sm"
+        leftSection={<Pencil size={14} />}
+      >
+        Edit
+      </Button>
+    </form>
+  );
+}

--- a/app/protected/Admin/Notices/page.tsx
+++ b/app/protected/Admin/Notices/page.tsx
@@ -5,7 +5,6 @@ import { getNotices, getMeetings } from './actions';
 import { Notice } from '@/types/Notice';
 import { Meeting } from '@/types/Meeting';
 
-
 export default async function AdminNoticesPage() {
   const notices: Notice[] = await getNotices();
   const meetings: Meeting[] = await getMeetings();
@@ -20,7 +19,7 @@ export default async function AdminNoticesPage() {
 
           <Flex direction="column" gap="sm" mt="sm" w="100%">
             {notices && notices.length > 0 ? (
-              notices.map((notice) => <NoticeCard key={notice.id} notice={notice} />)
+              notices.map((notice) => <NoticeCard key={notice.id} notice={notice} role="admin" />)
             ) : (
               <Text size="sm" c="dimmed">
                 No notices yet.
@@ -37,7 +36,9 @@ export default async function AdminNoticesPage() {
           </Text>
           <Flex direction="column" gap="sm" mt="sm" w="100%">
             {meetings && meetings.length > 0 ? (
-              meetings.map((meeting) => <MeetingCard key={meeting.id} meeting={meeting} />)
+              meetings.map((meeting) => (
+                <MeetingCard key={meeting.id} meeting={meeting} role="admin" />
+              ))
             ) : (
               <Text size="sm" c="dimmed">
                 No meetings yet.

--- a/components/MeetingCard.tsx
+++ b/components/MeetingCard.tsx
@@ -1,12 +1,15 @@
+import DeleteButtonMeeting from '@/app/protected/Admin/Notices/components/DeleteButtonMeeting';
+import EditButtonMeeting from '@/app/protected/Admin/Notices/components/EditButtonMeeting';
 import { Meeting } from '@/types/Meeting';
-import { Card, Text, Badge, Group, Avatar, Button } from '@mantine/core';
-import { Calendar, Clock, Pencil, Trash } from 'lucide-react';
+import { Card, Text, Badge, Group } from '@mantine/core';
+import { Calendar, Clock } from 'lucide-react';
 
 interface Props {
   meeting: Meeting;
+  role?: 'admin' | 'resident';
 }
 
-export default function MeetingCard({ meeting }: Props) {
+export default function MeetingCard({ meeting, role }: Props) {
   const formattedDate = new Date(meeting.meeting_date).toLocaleDateString('en-GB', {
     day: '2-digit',
     month: 'short',
@@ -41,26 +44,13 @@ export default function MeetingCard({ meeting }: Props) {
       <Text size="sm" c="dimmed" lh={1.5}>
         {meeting.description}
       </Text>
-      <Group justify="flex-end" mt="md">
-        <Button
-          variant="light"
-          color="blue"
-          radius="xl"
-          size="compact-sm"
-          leftSection={<Pencil size={14} />}
-        >
-          Edit
-        </Button>
-        <Button
-          variant="light"
-          color="red"
-          radius="xl"
-          size="compact-sm"
-          leftSection={<Trash size={14} />}
-        >
-          Delete
-        </Button>
-      </Group>
+
+      {role === 'admin' && (
+        <Group justify="flex-end" mt="md">
+          <EditButtonMeeting id={meeting.id} />
+          <DeleteButtonMeeting id={meeting.id} />
+        </Group>
+      )}
     </Card>
   );
 }

--- a/components/NoticeCard.tsx
+++ b/components/NoticeCard.tsx
@@ -1,13 +1,15 @@
 'use client';
 import { Card, Text, Badge, Group, Button } from '@mantine/core';
-import { Pencil, Trash } from 'lucide-react';
 import type { Notice } from '@/types/Notice';
+import DeleteButtonNotice from '@/app/protected/Admin/Notices/components/DeleteButtonNotice';
+import EditButtonNotice from '@/app/protected/Admin/Notices/components/EditButtonNotice';
 
 interface Props {
   notice: Notice;
+  role?: 'admin' | 'resident';
 }
 
-export default function NoticeCard({ notice }: Props) {
+export default function NoticeCard({ notice, role }: Props) {
   const date = new Date(notice.created_at);
   const formattedDate = `${date.getUTCDate().toString().padStart(2, '0')} ${date.toLocaleString(
     'en-GB',
@@ -20,7 +22,7 @@ export default function NoticeCard({ notice }: Props) {
     .getUTCMinutes()
     .toString()
     .padStart(2, '0')}`;
-    
+
   //defining the color of badge based on category
   const badgeColor =
     notice.category === 'General'
@@ -50,26 +52,12 @@ export default function NoticeCard({ notice }: Props) {
         {notice.content}
       </Text>
 
-      <Group justify="flex-end" mt="md">
-        <Button
-          variant="light"
-          color="blue"
-          radius="xl"
-          size="compact-sm"
-          leftSection={<Pencil size={14} />}
-        >
-          Edit
-        </Button>
-        <Button
-          variant="light"
-          color="red"
-          radius="xl"
-          size="compact-sm"
-          leftSection={<Trash size={14} />}
-        >
-          Delete
-        </Button>
-      </Group>
+      {role === 'admin' && (
+        <Group justify="flex-end" mt="md">
+          <EditButtonNotice id={notice.id} />
+          <DeleteButtonNotice id={notice.id} />
+        </Group>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
Closes #50 
- Introduced separate Edit and Delete button components for both notices and meetings, and updated NoticeCard and MeetingCard to render these buttons only for admin users.
- Updated the Admin Notices page to pass the 'admin' role to cards.