### PR TITLE
feat(admin):add delete functionality for notices and meetings

### DIFF
--- a/app/protected/Admin/Notices/actions.tsx
+++ b/app/protected/Admin/Notices/actions.tsx
@@ -1,17 +1,18 @@
 'use server';
 
-// import { revalidatePath } from 'next/cache';
+import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import { Meeting } from '@/types/Meeting';
 import type { Notice } from '@/types/Notice';
 
+//notices
 export async function getNotices(): Promise<Notice[]> {
   try {
     const supabase = await createClient();
     const { data, error } = await supabase
       .from('notices')
       .select('id, title, content, category, community_id, created_at')
-      .order('id', { ascending: true });
+      .order('created_at', { ascending: false });
     if (error) throw error;
     return data ?? [];
   } catch (err) {
@@ -19,17 +20,37 @@ export async function getNotices(): Promise<Notice[]> {
   }
 }
 
-
+//meetings
 export async function getMeetings(): Promise<Meeting[]> {
   try {
     const supabase = await createClient();
     const { data, error } = await supabase
       .from('meetings')
       .select('id, title, description, meeting_date')
-      .order('id', { ascending: true });
+      .order('meeting_date', { ascending: true });
     if (error) throw error;
     return data ?? [];
   } catch (err) {
     throw err;
   }
+}
+
+//delete Notice
+export async function deleteNotice(id: string) {
+  const supabase = await createClient();
+  const { error } = await supabase.from('notices').delete().eq('id', id);
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath('/protected/Admin/Notices');
+}
+
+//delete Meeting
+export async function deleteMeeting(id: string) {
+  const supabase = await createClient();
+  const { error } = await supabase.from('meetings').delete().eq('id', id);
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath('/protected/Admin/Notices');
 }

--- a/app/protected/Admin/Notices/components/DeleteButtonMeeting.tsx
+++ b/app/protected/Admin/Notices/components/DeleteButtonMeeting.tsx
@@ -1,8 +1,20 @@
 'use client';
 import { Button } from '@mantine/core';
 import { Trash } from 'lucide-react';
+import { deleteMeeting } from '@/app/protected/Admin/Notices/actions';
+import { useTransition } from 'react';
 
 export default function DeleteButtonMeeting({ id }: { id: string }) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = async () => {
+    const confirmed = confirm('Are you sure you want to delete this notice?');
+    if (!confirmed) return;
+    startTransition(async () => {
+      await deleteMeeting(id);
+    });
+  };
+
   return (
     <Button
       variant="light"
@@ -10,8 +22,10 @@ export default function DeleteButtonMeeting({ id }: { id: string }) {
       radius="xl"
       size="compact-sm"
       leftSection={<Trash size={14} />}
+      onClick={handleDelete}
+      disabled={isPending}
     >
-      Delete
+      {isPending ? 'Deleting...' : 'Delete'}
     </Button>
   );
 }

--- a/app/protected/Admin/Notices/components/DeleteButtonNotice.tsx
+++ b/app/protected/Admin/Notices/components/DeleteButtonNotice.tsx
@@ -1,8 +1,20 @@
 'use client';
 import { Button } from '@mantine/core';
 import { Trash } from 'lucide-react';
+import { deleteNotice } from '@/app/protected/Admin/Notices/actions';
+import { useTransition } from 'react';
 
 export default function DeleteButtonNotice({ id }: { id: string }) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = async () => {
+    const confirmed = confirm('Are you sure you want to delete this notice?');
+    if (!confirmed) return;
+    startTransition(async () => {
+      await deleteNotice(id);
+    });
+  };
+
   return (
     <Button
       variant="light"
@@ -10,8 +22,10 @@ export default function DeleteButtonNotice({ id }: { id: string }) {
       radius="xl"
       size="compact-sm"
       leftSection={<Trash size={14} />}
+      onClick={handleDelete}
+      disabled={isPending}
     >
-      Delete
+      {isPending ? 'Deleting...' : 'Delete'}
     </Button>
   );
 }


### PR DESCRIPTION
Closes #43 
- Implemented server actions to delete notices and meetings, including revalidation of the notices page.
- Updated delete buttons to include confirmation and loading states.
- Improved data sorting so newest notices and nearest meetings appear first.

