### PR TITLE
feat(admin):add update functionality to edit button in notice

### DIFF
--- a/app/protected/Admin/Notices/actions.tsx
+++ b/app/protected/Admin/Notices/actions.tsx
@@ -35,6 +35,27 @@ export async function getMeetings(): Promise<Meeting[]> {
   }
 }
 
+//edit/update Notice
+export async function updateNotice(
+  id: string,
+  values: { title: string; content: string; category: string }
+) {
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from('notices')
+    .update({
+      title: values.title,
+      content: values.content,
+      category: values.category,
+    })
+    .eq('id', id);
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath('/protected/Admin/Notices');
+}
+
 //delete Notice
 export async function deleteNotice(id: string) {
   const supabase = await createClient();

--- a/app/protected/Admin/Notices/components/EditButtonNotice.tsx
+++ b/app/protected/Admin/Notices/components/EditButtonNotice.tsx
@@ -2,18 +2,17 @@
 import { Button } from '@mantine/core';
 import { Pencil } from 'lucide-react';
 
-export default function EditButtonNotice({ id }: { id: string }) {
+export default function EditButtonNotice({ id, onClick }: { id: string; onClick?: () => void }) {
   return (
-    <form>
-      <Button
-        variant="light"
-        color="blue"
-        radius="xl"
-        size="compact-sm"
-        leftSection={<Pencil size={14} />}
-      >
-        Edit
-      </Button>
-    </form>
+    <Button
+      variant="light"
+      color="blue"
+      radius="xl"
+      size="compact-sm"
+      leftSection={<Pencil size={14} />}
+      onClick={onClick}
+    >
+      Edit
+    </Button>
   );
 }

--- a/app/protected/Admin/Notices/components/EditNoticeModal.tsx
+++ b/app/protected/Admin/Notices/components/EditNoticeModal.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Modal, TextInput, Textarea, Select, Button, Stack, Group } from '@mantine/core';
+import { useState } from 'react';
+import type { Notice } from '@/types/Notice';
+import { Type, FileText, Tags, Check } from 'lucide-react';
+
+interface Props {
+  opened: boolean;
+  onClose: () => void;
+  notice: Notice;
+  onSubmit: (values: { title: string; content: string; category: string }) => Promise<void> | void;
+}
+
+export default function EditNoticeModal({ opened, onClose, notice, onSubmit }: Props) {
+  const [title, setTitle] = useState(notice.title);
+  const [content, setContent] = useState(notice.content);
+  const [category, setCategory] = useState(notice.category);
+
+  const handleSave = async () => {
+    await onSubmit({ title, content, category });
+    onClose();
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Edit Notice" centered size="lg">
+      <Stack gap="md">
+        <TextInput
+          label="Title"
+          leftSection={<Type size={16} />}
+          value={title}
+          onChange={(e) => setTitle(e.currentTarget.value)}
+          onKeyDown={handleKeyPress}
+        />
+
+        <Textarea
+          label="Content"
+          leftSection={<FileText size={16} />}
+          autosize
+          minRows={2}
+          maxRows={6}
+          value={content}
+          onChange={(e) => setContent(e.currentTarget.value)}
+        />
+
+        <Select
+          label="Category"
+          leftSection={<Tags size={16} />}
+          data={['General', 'Maintenance', 'Safety']}
+          value={category}
+          onChange={(v) => v && setCategory(v)}
+          onKeyDown={handleKeyPress}
+        />
+
+        <Group justify="flex-end" mt="md">
+          <Button variant="light" color="gray" onClick={onClose}>
+            Cancel
+          </Button>
+
+          <Button leftSection={<Check size={16} />} onClick={handleSave}>
+            Save
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/components/NoticeCard.tsx
+++ b/components/NoticeCard.tsx
@@ -1,8 +1,11 @@
 'use client';
+import { useState } from 'react';
 import { Card, Text, Badge, Group, Button } from '@mantine/core';
 import type { Notice } from '@/types/Notice';
 import DeleteButtonNotice from '@/app/protected/Admin/Notices/components/DeleteButtonNotice';
 import EditButtonNotice from '@/app/protected/Admin/Notices/components/EditButtonNotice';
+import EditNoticeModal from '@/app/protected/Admin/Notices/components/EditNoticeModal';
+import { updateNotice } from '@/app/protected/Admin/Notices/actions';
 
 interface Props {
   notice: Notice;
@@ -10,6 +13,8 @@ interface Props {
 }
 
 export default function NoticeCard({ notice, role }: Props) {
+  const [opened, setOpened] = useState(false);
+
   const date = new Date(notice.created_at);
   const formattedDate = `${date.getUTCDate().toString().padStart(2, '0')} ${date.toLocaleString(
     'en-GB',
@@ -33,31 +38,44 @@ export default function NoticeCard({ notice, role }: Props) {
           ? 'blue'
           : 'gray';
 
+  const handleUpdate = async (values: { title: string; content: string; category: string }) => {
+    await updateNotice(notice.id, values);
+  };
+
   return (
-    <Card radius="md" padding="sm" withBorder style={{ maxWidth: 600, margin: '18xpx auto' }}>
-      <Group justify="space-between" mb="xs">
-        <Badge color={badgeColor} size="sm" variant="filled">
-          {notice.category}
-        </Badge>
-        <Text size="xs" c="gray">
-          Created at: {formattedDate}, {formattedTime},
-        </Text>
-      </Group>
-
-      <Text fw={600} size="md" mb={4}>
-        {notice.title}
-      </Text>
-
-      <Text size="sm" c="dimmed" lh={1.5}>
-        {notice.content}
-      </Text>
-
-      {role === 'admin' && (
-        <Group justify="flex-end" mt="md">
-          <EditButtonNotice id={notice.id} />
-          <DeleteButtonNotice id={notice.id} />
+    <>
+      <Card radius="md" padding="sm" withBorder style={{ maxWidth: 600, margin: '18xpx auto' }}>
+        <Group justify="space-between" mb="xs">
+          <Badge color={badgeColor} size="sm" variant="filled">
+            {notice.category}
+          </Badge>
+          <Text size="xs" c="gray">
+            Created at: {formattedDate}, {formattedTime},
+          </Text>
         </Group>
-      )}
-    </Card>
+
+        <Text fw={600} size="md" mb={4}>
+          {notice.title}
+        </Text>
+
+        <Text size="sm" c="dimmed" lh={1.5}>
+          {notice.content}
+        </Text>
+
+        {role === 'admin' && (
+          <Group justify="flex-end" mt="md">
+            <EditButtonNotice id={notice.id} onClick={() => setOpened(true)} />
+            <DeleteButtonNotice id={notice.id} />
+          </Group>
+        )}
+      </Card>
+
+      <EditNoticeModal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        notice={notice}
+        onSubmit={handleUpdate}
+      />
+    </>
   );
 }


### PR DESCRIPTION
Closes #41
- Introduced EditNoticeModal component for editing notices.
- Added updateNotice action for updating notices in the database.
- EditButtonNotice now accepts an onClick prop to trigger the modal.

<img width="1200" height="785" alt="Screenshot 2025-11-12 at 22 49 38" src="https://github.com/user-attachments/assets/0c222cca-cb18-42af-aa7f-2b1e99d5c67c" />
<img width="1200" height="785" alt="Screenshot 2025-11-12 at 22 49 58" src="https://github.com/user-attachments/assets/5449fcf4-de1c-4f01-a1e8-69e562329712" />
