### PR TITLE
feat(resident-notices):add resident notices and meetings display

### DIFF
--- a/app/protected/Resident/Notices/actions.tsx
+++ b/app/protected/Resident/Notices/actions.tsx
@@ -1,0 +1,63 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { Meeting } from '@/types/Meeting';
+import type { Notice } from '@/types/Notice';
+
+//notices
+export async function getNotices(): Promise<Notice[]> {
+  try {
+    const supabase = await createClient();
+
+    const { data: auth } = await supabase.auth.getUser();
+    if (!auth?.user) return [];
+
+    const { data: profile } = await supabase
+      .from('users')
+      .select('community_id')
+      .eq('id', auth.user.id)
+      .single();
+
+    if (!profile?.community_id) return [];
+
+    const { data, error } = await supabase
+      .from('notices')
+      .select('id, title, content, category, community_id, created_at')
+      .eq('community_id', profile.community_id)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+    return data ?? [];
+  } catch (err) {
+    throw err;
+  }
+}
+
+//meetings
+export async function getMeetings(): Promise<Meeting[]> {
+  try {
+    const supabase = await createClient();
+
+    const { data: auth } = await supabase.auth.getUser();
+    if (!auth?.user) return [];
+
+    const { data: profile } = await supabase
+      .from('users')
+      .select('community_id')
+      .eq('id', auth.user.id)
+      .single();
+
+    if (!profile?.community_id) return [];
+
+    const { data, error } = await supabase
+      .from('meetings')
+      .select('id, title, description, meeting_date, community_id')
+      .eq('community_id', profile.community_id)
+      .order('meeting_date', { ascending: true });
+
+    if (error) throw error;
+    return data ?? [];
+  } catch (err) {
+    throw err;
+  }
+}

--- a/app/protected/Resident/Notices/page.tsx
+++ b/app/protected/Resident/Notices/page.tsx
@@ -1,12 +1,54 @@
-import { Container, Title, Text } from '@mantine/core';
+import { Flex, Divider, Group, Text } from '@mantine/core';
+import NoticeCard from '@/components/NoticeCard';
+import MeetingCard from '@/components/MeetingCard';
+import { getNotices, getMeetings } from './actions';
+import { Notice } from '@/types/Notice';
+import { Meeting } from '@/types/Meeting';
 
-export default function ResidentNoticesPage() {
+export default async function ResidentNoticesPage() {
+  const notices: Notice[] = await getNotices();
+  const meetings: Meeting[] = await getMeetings();
+
   return (
-    <Container size="lg" py="lg">
-      <Title order={2}>Notices</Title>
-      <Text mt="sm" c="dimmed">
-        This is the resident notices page. Later you can list all notices from your association here.
-      </Text>
-    </Container>
+    <>
+      <Flex justify="center" align="flex-start" gap="lg" mt="lg" px="md">
+        <Group style={{ flex: 1, minWidth: 320, maxWidth: 500 }} align="flex-start">
+          <Text size="xl" fw={700}>
+            Notices
+          </Text>
+
+          <Flex direction="column" gap="sm" mt="sm" w="100%">
+            {notices && notices.length > 0 ? (
+              notices.map((notice) => (
+                <NoticeCard key={notice.id} notice={notice} role="resident" />
+              ))
+            ) : (
+              <Text size="sm" c="dimmed">
+                No notices yet.
+              </Text>
+            )}
+          </Flex>
+        </Group>
+
+        <Divider orientation="vertical" color="#e9ecef" />
+
+        <Group style={{ flex: 1, minWidth: 320, maxWidth: 500 }}>
+          <Text size="xl" fw={700}>
+            Meetings
+          </Text>
+          <Flex direction="column" gap="sm" mt="sm" w="100%">
+            {meetings && meetings.length > 0 ? (
+              meetings.map((meeting) => (
+                <MeetingCard key={meeting.id} meeting={meeting} role="resident" />
+              ))
+            ) : (
+              <Text size="sm" c="dimmed">
+                No meetings yet.
+              </Text>
+            )}
+          </Flex>
+        </Group>
+      </Flex>
+    </>
   );
 }


### PR DESCRIPTION
Closes #21 

- Introduces server actions to fetch notices and meetings for the logged-in resident's community.
- Updates the Resident Notices page to display both using NoticeCard and MeetingCard components.


### Shows how community_id restricts data so each resident only sees notices and meetings from their own community
Resident 1 belongs to a community called "New Community".
<img width="1200" height="706" alt="Screenshot 2025-11-20 at 23 49 40" src="https://github.com/user-attachments/assets/ad6daab8-a497-4ccc-a991-f85e8a175b89" />


Resident 2 belongs to a community called "Test Community".
<img width="1200" height="706" alt="Screenshot 2025-11-20 at 23 47 04" src="https://github.com/user-attachments/assets/bdf6774c-f77b-4165-b9af-2d74e235eafb" />
