### PR TITLE
feat(meetings):include duration in meetings

### DIFF
--- a/app/protected/Resident/Notices/actions.tsx
+++ b/app/protected/Resident/Notices/actions.tsx
@@ -51,7 +51,7 @@ export async function getMeetings(): Promise<Meeting[]> {
 
     const { data, error } = await supabase
       .from('meetings')
-      .select('id, title, description, meeting_date, community_id')
+      .select('id, title, description, meeting_date, community_id, duration')
       .eq('community_id', profile.community_id)
       .order('meeting_date', { ascending: true });
 


### PR DESCRIPTION
Closes #73
- Added the 'duration' field to the show up the duration of meeting.

<img width="666" height="706" alt="Screenshot 2025-11-21 at 18 11 27" src="https://github.com/user-attachments/assets/253299a4-7197-4a95-9474-20362bd04a17" />
