### PR TITLE
feat(admin): integrate community_id filtering for residents and worries pages

### DIFF
--- a/types/community.ts
+++ b/types/community.ts
@@ -1,0 +1,5 @@
+export type CommunityId = string;
+
+export interface WithCommunityId {
+  community_id: CommunityId;
+}


### PR DESCRIPTION
- Added community_id type under /types/community
- Implemented environment-based community_id resolution
- Updated Admin Residents page to fetch only users in the same community
- Updated Admin Worries page to filter worries by community_id
- Removed hard-coded IDs and replaced with env-based filtering

Closes #66