### PR TITLE
feat(notice): add success notification to Create Notice form 

### DIFF
--- a/app/protected/Admin/CreateNotice/components/CreateNoticeForm.tsx
+++ b/app/protected/Admin/CreateNotice/components/CreateNoticeForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mantine/core";
 import { useState, useTransition } from "react";
 import { createNotice } from "../actions";
+import { notifications } from "@mantine/notifications";
 
 export default function CreateNoticeForm() {
   const [isPending, startTransition] = useTransition();
@@ -49,7 +50,11 @@ export default function CreateNoticeForm() {
       try {
         await createNotice(formData);
 
-        setSuccess("Notice successfully created!");
+        notifications.show({
+          title: "Notice created",
+          message: "The notice was successfully created!",
+          color: "green",
+        });
         setTitle("");
         setContent("");
         setCategory("General");


### PR DESCRIPTION
closes #93 

- Replaced inline success message with a notification
- Cleaned up form state reset after submission
- Improved user feedback UX
- 
<img width="1131" height="597" alt="image" src="https://github.com/user-attachments/assets/02e4946a-05b0-4b43-bd38-95fe19b039b3" />


