### PR TITLE
feat(filters): add Notice Filters to admin and resident pages

### DIFF
--- a/app/protected/Admin/Notices/actions.tsx
+++ b/app/protected/Admin/Notices/actions.tsx
@@ -7,7 +7,9 @@ import type { Notice } from '@/types/Notice';
 
 export async function getNotices(
   page = 1,
-  limit = 1 // 
+  limit = 1, // 
+  category?: string,
+  sort: 'newest' | 'oldest' = 'newest'
 ): Promise<{ data: Notice[]; count: number }> {
   try {
     const supabase = await createClient();
@@ -26,13 +28,18 @@ export async function getNotices(
     const from = (page - 1) * limit;
     const to = from + limit - 1;
 
-    const { data, count, error } = await supabase
+    let query = supabase
       .from('notices')
       .select('id, title, content, category, community_id, created_at', { count: 'exact' })
-      .eq('community_id', profile.community_id)
-      .order('created_at', { ascending: false })
-      .range(from, to);
+      .eq('community_id', profile.community_id);
 
+    if (category && category !== '') {
+      query = query.eq('category', category);
+    }
+
+    query = query.order('created_at', { ascending: sort === 'oldest' });
+
+    const { data, count, error } = await query.range(from, to);
     if (error) throw error;
 
     return { data: data ?? [], count: count ?? 0 };

--- a/app/protected/Admin/Notices/components/EditNoticeModal.tsx
+++ b/app/protected/Admin/Notices/components/EditNoticeModal.tsx
@@ -10,9 +10,10 @@ interface Props {
   onClose: () => void;
   notice: Notice;
   onSubmit: (values: { title: string; content: string; category: string }) => Promise<void> | void;
+  onAfterSave?: () => void;
 }
 
-export default function EditNoticeModal({ opened, onClose, notice, onSubmit }: Props) {
+export default function EditNoticeModal({ opened, onClose, notice, onSubmit, onAfterSave }: Props) {
   const [title, setTitle] = useState(notice.title);
   const [content, setContent] = useState(notice.content);
   const [category, setCategory] = useState(notice.category);
@@ -20,6 +21,7 @@ export default function EditNoticeModal({ opened, onClose, notice, onSubmit }: P
   const handleSave = async () => {
     await onSubmit({ title, content, category });
     onClose();
+    if (onAfterSave) onAfterSave();
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {

--- a/app/protected/Resident/Notices/page.tsx
+++ b/app/protected/Resident/Notices/page.tsx
@@ -8,6 +8,7 @@ import MeetingCard from '@/components/MeetingCard';
 import { getNotices, getMeetings } from './actions';
 import { Notice } from '@/types/Notice';
 import { Meeting } from '@/types/Meeting';
+import FiltersNotices from '@/components/FiltersNotices';
 
 export default function ResidentNoticesPage() {
   const searchParams = useSearchParams();
@@ -16,6 +17,15 @@ export default function ResidentNoticesPage() {
   const pageParam = searchParams.get('page');
   const initialPage = Number(pageParam) || 1;
 
+  const category = searchParams.get('category') ?? '';
+  const sort = (searchParams.get('sort') as 'newest' | 'oldest') ?? 'newest';
+
+  const buildPageUrl = (newPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", String(newPage));
+    return `?${params.toString()}`;
+  };
+  
   const [page, setPage] = useState(initialPage);
   const [notices, setNotices] = useState<Notice[]>([]);
   const [count, setCount] = useState(0);
@@ -28,7 +38,7 @@ export default function ResidentNoticesPage() {
 
   useEffect(() => {
     async function fetchData() {
-      const { data, count } = await getNotices(page, itemsPerPage);
+      const { data, count } = await getNotices(page, itemsPerPage, category || undefined, sort);
       setNotices(data);
       setCount(count);
 
@@ -36,7 +46,7 @@ export default function ResidentNoticesPage() {
       setMeetings(meetingsData);
     }
     fetchData();
-  }, [page]);
+  }, [page, category, sort]);
 
   const totalPages = Math.ceil(count / itemsPerPage);
 
@@ -44,7 +54,10 @@ export default function ResidentNoticesPage() {
     <Flex justify="center" align="flex-start" gap="lg" mt="lg" px="md">
       {/* NOTICES */}
       <Group style={{ flex: 1, minWidth: 320, maxWidth: 500 }} align="flex-start">
-        <Text size="xl" fw={700}>Notices</Text>
+        <Flex justify="space-between" align="center" w="100%">
+          <Text size="xl" fw={700}>Notices</Text>
+          <FiltersNotices />
+        </Flex>
         <Flex direction="column" gap="sm" mt="sm" w="100%">
           {notices.length > 0 ? (
             notices.map((notice) => (
@@ -65,7 +78,7 @@ export default function ResidentNoticesPage() {
                 fw={600}
                 c="blue"
                 style={{ cursor: 'pointer' }}
-                onClick={() => router.push(`?page=${page - 1}`)}
+                onClick={() => router.push(buildPageUrl(page - 1))}
               >
                 ← Previous
               </Text>
@@ -76,7 +89,7 @@ export default function ResidentNoticesPage() {
                 fw={600}
                 c="blue"
                 style={{ cursor: 'pointer' }}
-                onClick={() => router.push(`?page=${page + 1}`)}
+                onClick={() => router.push(buildPageUrl(page + 1))}
               >
                 Next →
               </Text>

--- a/components/FiltersNotices.tsx
+++ b/components/FiltersNotices.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { Menu, Button } from "@mantine/core";
+import { Funnel, Check, Wrench, Shield, FolderKanban, ListFilter } from "lucide-react";
+
+export default function FiltersNotices() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const currentCategory = searchParams.get("category") || "";
+  const currentSort = searchParams.get("sort") || "newest";
+
+  const updateFilter = (key: string, value: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (value === null) params.delete(key);
+    else params.set(key, value);
+
+    params.delete("page");
+
+    router.push(`?${params.toString()}`);
+  };
+
+  const MenuItem = (
+    label: string,
+    value: string | null,
+    icon: React.ReactNode,
+    active: boolean,
+    key: string
+  ) => (
+    <Menu.Item
+      onClick={() => updateFilter(key, value)}
+      leftSection={icon}
+      rightSection={active ? <Check size={16} color="#1c7ed6" /> : null}
+      style={{
+        fontWeight: active ? 600 : 400,
+      }}
+    >
+      {label}
+    </Menu.Item>
+  );
+
+  return (
+    <Menu width={220} position="bottom-end" shadow="md" radius="md">
+      <Menu.Target>
+        <Button
+          variant="outline"
+          color="blue"
+          size="sm"
+          leftSection={<Funnel size={16} />}
+        >
+          Filter
+        </Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Label style={{ fontSize: 13, opacity: 0.8 }}>Category</Menu.Label>
+
+        {MenuItem("All", null, <ListFilter size={16} />, currentCategory === "", "category")}
+        {MenuItem("Maintenance", "Maintenance", <Wrench size={16} />, currentCategory === "Maintenance", "category")}
+        {MenuItem("Safety", "Safety", <Shield size={16} />, currentCategory === "Safety", "category")}
+        {MenuItem("General", "General", <FolderKanban size={16} />, currentCategory === "General", "category")}
+
+        <Menu.Divider />
+
+        <Menu.Label style={{ fontSize: 13, opacity: 0.8 }}>Sort by date</Menu.Label>
+
+        {MenuItem("Newest first", "newest", <ListFilter size={16} />, currentSort === "newest", "sort")}
+        {MenuItem("Oldest first", "oldest", <ListFilter size={16} />, currentSort === "oldest", "sort")}
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/components/NoticeCard.tsx
+++ b/components/NoticeCard.tsx
@@ -12,9 +12,10 @@ interface Props {
   role?: 'admin' | 'resident';
   onUpdate?: (values: { title: string; content: string; category: string }) => void; // 
   onDelete?: () => void; 
+  onAfterSave?: () => void; 
 }
 
-export default function NoticeCard({ notice, role, onUpdate, onDelete }: Props) {
+export default function NoticeCard({ notice, role, onUpdate, onDelete, onAfterSave }: Props) {
   const [opened, setOpened] = useState(false);
 
   const date = new Date(notice.created_at);
@@ -81,6 +82,7 @@ export default function NoticeCard({ notice, role, onUpdate, onDelete }: Props) 
         onClose={() => setOpened(false)}
         notice={notice}
         onSubmit={handleUpdate} 
+        onAfterSave={onAfterSave}
       />
     </>
   );


### PR DESCRIPTION
Closes #79 

- Introduces a FiltersNotices component for filtering and sorting notices by category and date in Admin and Resident role.
- Updates getNotices to support category and sort parameters.
- Also adds onAfterSave callbacks to refresh notices after UPDATE(edit) in admin role.
- Changed the logic of pagination to support it with filters.


**Admin Panel**
<img width="1200" height="710" alt="Screenshot 2025-11-27 at 21 52 48" src="https://github.com/user-attachments/assets/ad724437-5516-4149-860c-11f12cdea676" />
Category = "Maintenance", Sort by date = "Oldest"
<img width="1200" height="710" alt="Screenshot 2025-11-27 at 21 50 39" src="https://github.com/user-attachments/assets/2a303d3a-ed3b-4dea-8a07-70de9ff6c71a" />

**User Panel**
Works the same as admin panel.
<img width="1200" height="710" alt="Screenshot 2025-11-27 at 21 52 00" src="https://github.com/user-attachments/assets/6b440117-58a0-41f2-8d6c-735f09ce6e7d" />




