### PR TITLE
fix(admin):fix date formatting

### DIFF
--- a/components/NoticeCard.tsx
+++ b/components/NoticeCard.tsx
@@ -16,17 +16,19 @@ interface Props {
 
 export default function NoticeCard({ notice, role, onUpdate, onDelete }: Props) {
   const [opened, setOpened] = useState(false);
+  const date = new Date(notice.created_at + "Z");
 
-  const date = new Date(notice.created_at);
-  const formattedDate = `${date.getUTCDate().toString().padStart(2, '0')} ${date.toLocaleString(
-    'en-GB',
-    { month: 'short' }
-  )} ${date.getUTCFullYear()}`;
+  const formattedDate = date.toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
 
-  const formattedTime = `${date.getUTCHours().toString().padStart(2, '0')}:${date
-    .getUTCMinutes()
-    .toString()
-    .padStart(2, '0')}`;
+  const formattedTime = date.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
 
   const badgeColor =
     notice.category === 'General'


### PR DESCRIPTION
Closes #95

- Updated the date and time formatting in NoticeCard to show the right time , not UTC timezone.

<img width="523" height="169" alt="Screenshot 2025-11-27 at 22 42 05" src="https://github.com/user-attachments/assets/35d0fca4-e8ba-4e49-bc98-2684ce02eab3" />
