### PR TITLE
feat(create-meeting):add notifications for meeting creation and errors

### DIFF
--- a/app/protected/Admin/Create-Meetings/components/CreateMeetingForm.tsx
+++ b/app/protected/Admin/Create-Meetings/components/CreateMeetingForm.tsx
@@ -107,14 +107,12 @@ export default function CreateMeetingForm() {
           };
 
           const message = map[err.message] ?? 'Unexpected server error.';
-          setError(message);
           notifications.show({
             title: 'Error',
             message: message,
             color: 'red',
           });
         } else {
-          setError('Unexpected server error.');
           notifications.show({
             title: 'Error',
             message: 'An unexpected error occurred. Please try again later.',


### PR DESCRIPTION
Closes #97 

- Integrated notifications to provide user feedback upon successful meeting creation and when errors occur.

**Successful notification** 
<img width="1200" height="708" alt="Screenshot 2025-11-27 at 22 45 51" src="https://github.com/user-attachments/assets/3b27199e-f1f2-49fc-96f3-f3d93208a6d7" />
**Error notification** 
<img width="1200" height="708" alt="Screenshot 2025-11-27 at 22 55 47" src="https://github.com/user-attachments/assets/910773d5-d936-409e-a034-2533c9eb820b" />
