### PR TITLE
feat(filters):add sorting filters to worries pages

### DIFF
--- a/app/protected/Admin/Worries/page.tsx
+++ b/app/protected/Admin/Worries/page.tsx
@@ -1,18 +1,12 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
-import {
-  Card,
-  Text,
-  Group,
-  Stack,
-  Loader,
-  Center,
-  ScrollArea,
-} from '@mantine/core';
+import { Card, Text, Group, Stack, Loader, Center, ScrollArea, Flex, Badge } from '@mantine/core';
 import { Button } from '@/components/ui/button';
 import type { CommunityId } from '@/types/community';
+import FiltersWorries from '@/components/FiltersWorries';
 
 type Worry = {
   id: string;
@@ -30,6 +24,9 @@ const COMMUNITY_ID: CommunityId | '' =
   (process.env.NEXT_PUBLIC_COMMUNITY_ID as CommunityId | undefined) ?? '';
 
 export default function AdminWorriesPage() {
+  const searchParams = useSearchParams();
+  const sort = searchParams.get('sort') || 'newest';
+
   const [worries, setWorries] = useState<Worry[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -42,7 +39,7 @@ export default function AdminWorriesPage() {
         const query = supabase
           .from('worries')
           .select('id, title, content, created_at, created_by, community_id')
-          .order('created_at', { ascending: false });
+          .order('created_at', { ascending: sort === 'oldest' });
 
         // Kui COMMUNITY_ID on seadistatud, filtreeri selle järgi
         if (COMMUNITY_ID) {
@@ -66,7 +63,7 @@ export default function AdminWorriesPage() {
     };
 
     fetchWorries();
-  }, []);
+  }, [sort]);
 
   const handleDelete = async (id: string) => {
     const confirmed = window.confirm(
@@ -98,9 +95,23 @@ export default function AdminWorriesPage() {
   return (
     <ScrollArea style={{ maxHeight: 'calc(100vh - 80px)' }} px="md" py="lg">
       <Stack gap="md">
-        <Text fw={700} size="xl">
-          Resident worries
-        </Text>
+        <Flex justify="space-between" align="center" w="100%">
+          <Text size="xl" fw={700}>
+            Resident worries
+          </Text>
+          <FiltersWorries />
+        </Flex>
+        <Flex gap="xs" mt={-4} justify="flex-end" align="center" w="100%">
+          <Badge
+            color="blue"
+            variant="light"
+            radius="xl"
+            size="sm"
+            styles={{ root: { paddingLeft: 12, paddingRight: 12 } }}
+          >
+            {sort === 'newest' ? 'Newest' : 'Oldest'}
+          </Badge>
+        </Flex>
 
         {worries.length === 0 && (
           <Text c="dimmed" size="sm">

--- a/app/protected/Resident/Worries/page.tsx
+++ b/app/protected/Resident/Worries/page.tsx
@@ -1,15 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
-import {
-  Card,
-  Text,
-  Stack,
-  Loader,
-  Center,
-  ScrollArea,
-} from '@mantine/core';
+import { Card, Text, Stack, Loader, Center, ScrollArea, Badge, Flex } from '@mantine/core';
+import FiltersWorries from '@/components/FiltersWorries';
 
 type Worry = {
   id: string;
@@ -22,6 +17,9 @@ type Worry = {
 const supabase = createClient();
 
 export default function ResidentWorriesPage() {
+  const searchParams = useSearchParams();
+  const sort = searchParams.get('sort') || 'newest';
+
   const [worries, setWorries] = useState<Worry[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -32,8 +30,7 @@ export default function ResidentWorriesPage() {
       const { data, error } = await supabase
         .from('worries')
         .select('id, title, content, created_at')
-        .order('created_at', { ascending: false });
-
+        .order('created_at', { ascending: sort === 'oldest' });
       if (error) {
         console.error('Error fetching resident worries:', error.message);
         setWorries([]);
@@ -45,7 +42,7 @@ export default function ResidentWorriesPage() {
     };
 
     fetchWorries();
-  }, []);
+  }, [sort]);
 
   if (loading) {
     return (
@@ -58,9 +55,23 @@ export default function ResidentWorriesPage() {
   return (
     <ScrollArea style={{ maxHeight: 'calc(100vh - 80px)' }} px="md" py="lg">
       <Stack gap="md">
-        <Text fw={700} size="xl">
-          Worries
-        </Text>
+        <Flex justify="space-between" align="center" w="100%">
+          <Text size="xl" fw={700}>
+            Worries
+          </Text>
+          <FiltersWorries />
+        </Flex>
+        <Flex gap="xs" mt={-4} justify="flex-end" align="center" w="100%">
+          <Badge
+            color="blue"
+            variant="light"
+            radius="xl"
+            size="sm"
+            styles={{ root: { paddingLeft: 12, paddingRight: 12 } }}
+          >
+            {sort === 'newest' ? 'Newest' : 'Oldest'}
+          </Badge>
+        </Flex>
 
         {worries.length === 0 && (
           <Text c="dimmed" size="sm">

--- a/components/FiltersWorries.tsx
+++ b/components/FiltersWorries.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Menu, Button } from '@mantine/core';
+import { Funnel, Check, ListFilter } from 'lucide-react';
+
+export default function FiltersWorries() {
+
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const currentSort = searchParams.get('sort') || 'newest';
+
+  const handleSort = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('sort', value);
+    router.replace(`?${params.toString()}`);
+  };
+
+  return (
+    <Menu width={220} position="bottom-end" shadow="md" radius="md">
+      <Menu.Target>
+        <Button variant="outline" color="blue" size="sm" leftSection={<Funnel size={16} />}>
+          Filters
+        </Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        <Menu.Label style={{ fontSize: 13, opacity: 0.8 }}>Sort by date</Menu.Label>
+
+        <Menu.Item
+          leftSection={<ListFilter size={16} />}
+          rightSection={currentSort === 'newest' ? <Check size={16} color="#1c7ed6" /> : null}
+          onClick={() => handleSort('newest')}
+          style={{ fontWeight: currentSort === 'newest' ? 600 : 400 }}
+        >
+          Newest
+        </Menu.Item>
+
+        <Menu.Item
+          leftSection={<ListFilter size={16} />}
+          rightSection={currentSort === 'oldest' ? <Check size={16} color="#1c7ed6" /> : null}
+          onClick={() => handleSort('oldest')}
+          style={{ fontWeight: currentSort === 'oldest' ? 600 : 400 }}
+        >
+          Oldest
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}


### PR DESCRIPTION
Closes #80 

- Introduces a FiltersWorries component for sorting worries in both roles
- Added badges for user to see what user has chosen

**Component**
<img width="296" height="193" alt="Screenshot 2025-11-28 at 14 43 32" src="https://github.com/user-attachments/assets/61a3cdb0-9e99-4ad3-a478-096ea719958b" />

**Resident Panel**
<img width="1200" height="787" alt="Screenshot 2025-11-28 at 14 42 45" src="https://github.com/user-attachments/assets/77bd8608-80fa-4795-8460-cb4ad878669f" />
**Admin Panel**
<img width="1200" height="789" alt="Screenshot 2025-11-28 at 14 44 15" src="https://github.com/user-attachments/assets/b3ab3e21-fbf9-47c4-8fb4-2a95d497f681" />



