### PR TITLE
feat(filters-UI):add filters badges for UI

### DIFF
--- a/app/protected/Admin/Notices/page.tsx
+++ b/app/protected/Admin/Notices/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { Flex, Divider, Group, Text } from '@mantine/core';
+import { Flex, Divider, Group, Text, Badge } from '@mantine/core';
 import NoticeCard from '@/components/NoticeCard';
 import MeetingCard from '@/components/MeetingCard';
 import { getNotices, getMeetings } from './actions';
@@ -24,45 +24,51 @@ export default function AdminNoticesPage() {
   const [notices, setNotices] = useState<Notice[]>([]);
   const [count, setCount] = useState(0);
   const [meetings, setMeetings] = useState<Meeting[]>([]);
-  const itemsPerPage = 3;//sina muuta voime kus palju lehel naitame teadet
+  const itemsPerPage = 3; //sina muuta voime kus palju lehel naitame teadet
 
   const buildPageUrl = (newPage: number) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set("page", String(newPage));
+    params.set('page', String(newPage));
     return `?${params.toString()}`;
   };
-  
-  const handleUpdateNotice = (id: string, values: { title: string; content: string; category: string }) => {
-    setNotices(prev => prev.map(n => n.id === id ? { ...n, ...values } : n));
+
+  const handleUpdateNotice = (
+    id: string,
+    values: { title: string; content: string; category: string }
+  ) => {
+    setNotices((prev) => prev.map((n) => (n.id === id ? { ...n, ...values } : n)));
   };
 
-   const handleDeleteNotice = async (id: string) => {
-  setNotices(prev => prev.filter(n => n.id !== id));
-  setCount(prev => prev - 1);
+  const handleDeleteNotice = async (id: string) => {
+    setNotices((prev) => prev.filter((n) => n.id !== id));
+    setCount((prev) => prev - 1);
 
-  if (notices.length === 1 && page > 1) {
-    const newPage = page - 1;
-    setPage(newPage);
-    router.push(buildPageUrl(newPage));
-    const { data } = await getNotices(newPage, itemsPerPage, category, sort);
-    setNotices(data);
-    return;
-  }
+    if (notices.length === 1 && page > 1) {
+      const newPage = page - 1;
+      setPage(newPage);
+      router.push(buildPageUrl(newPage));
+      const { data } = await getNotices(newPage, itemsPerPage, category, sort);
+      setNotices(data);
+      return;
+    }
 
-  // 
-  const currentLength = notices.length;
-  if (currentLength - 1 < itemsPerPage && page * itemsPerPage < count) {
-    const { data } = await getNotices(page, itemsPerPage, category, sort);
-    setNotices(data);
-  }
-};
+    //
+    const currentLength = notices.length;
+    if (currentLength - 1 < itemsPerPage && page * itemsPerPage < count) {
+      const { data } = await getNotices(page, itemsPerPage, category, sort);
+      setNotices(data);
+    }
+  };
 
-  const handleUpdateMeeting = (id: string, values: { title: string; description: string; meeting_date: string; duration: string }) => {
-  setMeetings(prev => prev.map(m => m.id === id ? { ...m, ...values } : m));
-};
+  const handleUpdateMeeting = (
+    id: string,
+    values: { title: string; description: string; meeting_date: string; duration: string }
+  ) => {
+    setMeetings((prev) => prev.map((m) => (m.id === id ? { ...m, ...values } : m)));
+  };
 
   const handleDeleteMeeting = (id: string) => {
-  setMeetings(prev => prev.filter(m => m.id !== id));
+    setMeetings((prev) => prev.filter((m) => m.id !== id));
   };
 
   //for update functionality after changing the category of notices
@@ -95,10 +101,33 @@ export default function AdminNoticesPage() {
       {/* NOTICES */}
       <Group style={{ flex: 1, minWidth: 320, maxWidth: 500 }} align="flex-start">
         <Flex justify="space-between" align="center" w="100%">
-          <Text size="xl" fw={700}>Notices</Text>
+          <Text size="xl" fw={700}>
+            Notices
+          </Text>
           <FiltersNotices />
         </Flex>
-        <Flex direction="column" gap="sm" mt="sm" w="100%">
+        <Flex gap="xs" mt={-4} justify="flex-end" align="center" w="100%">
+          <Badge
+            color="blue"
+            variant="light"
+            radius="xl"
+            size="sm"
+            styles={{ root: { paddingLeft: 12, paddingRight: 12 } }}
+          >
+            {category === '' ? 'All' : category}
+          </Badge>
+          <Badge
+            color="blue"
+            variant="light"
+            radius="xl"
+            size="sm"
+            styles={{ root: { paddingLeft: 12, paddingRight: 12 } }}
+          >
+            {sort === 'newest' ? 'Newest' : 'Oldest'}
+          </Badge>
+        </Flex>
+
+        <Flex direction="column" gap="sm" w="100%">
           {notices.length > 0 ? (
             notices.map((notice) => (
               <NoticeCard
@@ -111,7 +140,9 @@ export default function AdminNoticesPage() {
               />
             ))
           ) : (
-            <Text size="sm" c="dimmed">No notices yet.</Text>
+            <Text size="sm" c="dimmed">
+              No notices yet.
+            </Text>
           )}
 
           {/* Pagination */}
@@ -126,7 +157,9 @@ export default function AdminNoticesPage() {
                 ← Previous
               </Text>
             )}
-            <Text>{page} / {totalPages}</Text>
+            <Text>
+              {page} / {totalPages}
+            </Text>
             {page < totalPages && (
               <Text
                 fw={600}
@@ -145,21 +178,25 @@ export default function AdminNoticesPage() {
 
       {/* MEETINGS */}
       <Group style={{ flex: 1, minWidth: 320, maxWidth: 500 }}>
-        <Text size="xl" fw={700}>Meetings</Text>
+        <Text size="xl" fw={700}>
+          Meetings
+        </Text>
         <Flex direction="column" gap="sm" mt="sm" w="100%">
           {meetings.length > 0 ? (
-          meetings.map((meeting) => (
-            <MeetingCard
-              key={meeting.id}
-              meeting={meeting}
-              role="admin"
-              onUpdate={(values) => handleUpdateMeeting(meeting.id, values)}
-              onDelete={() => handleDeleteMeeting(meeting.id)}
-            />
-          ))
-        ) : (
-          <Text size="sm" c="dimmed">No meetings yet.</Text>
-        )}
+            meetings.map((meeting) => (
+              <MeetingCard
+                key={meeting.id}
+                meeting={meeting}
+                role="admin"
+                onUpdate={(values) => handleUpdateMeeting(meeting.id, values)}
+                onDelete={() => handleDeleteMeeting(meeting.id)}
+              />
+            ))
+          ) : (
+            <Text size="sm" c="dimmed">
+              No meetings yet.
+            </Text>
+          )}
         </Flex>
       </Group>
     </Flex>

--- a/app/protected/Resident/Notices/page.tsx
+++ b/app/protected/Resident/Notices/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { Flex, Divider, Group, Text } from '@mantine/core';
+import { Flex, Divider, Group, Text, Badge } from '@mantine/core';
 import NoticeCard from '@/components/NoticeCard';
 import MeetingCard from '@/components/MeetingCard';
 import { getNotices, getMeetings } from './actions';
@@ -22,10 +22,10 @@ export default function ResidentNoticesPage() {
 
   const buildPageUrl = (newPage: number) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set("page", String(newPage));
+    params.set('page', String(newPage));
     return `?${params.toString()}`;
   };
-  
+
   const [page, setPage] = useState(initialPage);
   const [notices, setNotices] = useState<Notice[]>([]);
   const [count, setCount] = useState(0);
@@ -55,20 +55,39 @@ export default function ResidentNoticesPage() {
       {/* NOTICES */}
       <Group style={{ flex: 1, minWidth: 320, maxWidth: 500 }} align="flex-start">
         <Flex justify="space-between" align="center" w="100%">
-          <Text size="xl" fw={700}>Notices</Text>
+          <Text size="xl" fw={700}>
+            Notices
+          </Text>
           <FiltersNotices />
         </Flex>
-        <Flex direction="column" gap="sm" mt="sm" w="100%">
+        <Flex gap="xs" mt={-4} justify="flex-end" align="center" w="100%">
+          <Badge
+            color="blue"
+            variant="light"
+            radius="xl"
+            size="sm"
+            styles={{ root: { paddingLeft: 12, paddingRight: 12 } }}
+          >
+            {category === '' ? 'All' : category}
+          </Badge>
+          <Badge
+            color="blue"
+            variant="light"
+            radius="xl"
+            size="sm"
+            styles={{ root: { paddingLeft: 12, paddingRight: 12 } }}
+          >
+            {sort === 'newest' ? 'Newest' : 'Oldest'}
+          </Badge>
+        </Flex>
+
+        <Flex direction="column" gap="sm" w="100%">
           {notices.length > 0 ? (
-            notices.map((notice) => (
-              <NoticeCard
-                key={notice.id}
-                notice={notice}
-                role="resident"
-              />
-            ))
+            notices.map((notice) => <NoticeCard key={notice.id} notice={notice} role="resident" />)
           ) : (
-            <Text size="sm" c="dimmed">No notices yet.</Text>
+            <Text size="sm" c="dimmed">
+              No notices yet.
+            </Text>
           )}
 
           {/* Pagination */}
@@ -83,7 +102,9 @@ export default function ResidentNoticesPage() {
                 ← Previous
               </Text>
             )}
-            <Text>{page} / {totalPages}</Text>
+            <Text>
+              {page} / {totalPages}
+            </Text>
             {page < totalPages && (
               <Text
                 fw={600}
@@ -102,18 +123,18 @@ export default function ResidentNoticesPage() {
 
       {/* MEETINGS */}
       <Group style={{ flex: 1, minWidth: 320, maxWidth: 500 }}>
-        <Text size="xl" fw={700}>Meetings</Text>
+        <Text size="xl" fw={700}>
+          Meetings
+        </Text>
         <Flex direction="column" gap="sm" mt="sm" w="100%">
           {meetings.length > 0 ? (
             meetings.map((meeting) => (
-              <MeetingCard
-                key={meeting.id}
-                meeting={meeting}
-                role="resident"
-              />
+              <MeetingCard key={meeting.id} meeting={meeting} role="resident" />
             ))
           ) : (
-            <Text size="sm" c="dimmed">No meetings yet.</Text>
+            <Text size="sm" c="dimmed">
+              No meetings yet.
+            </Text>
           )}
         </Flex>
       </Group>

--- a/components/FiltersNotices.tsx
+++ b/components/FiltersNotices.tsx
@@ -1,15 +1,15 @@
-"use client";
+'use client';
 
-import { useSearchParams, useRouter } from "next/navigation";
-import { Menu, Button } from "@mantine/core";
-import { Funnel, Check, Wrench, Shield, FolderKanban, ListFilter } from "lucide-react";
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Menu, Button, Badge, Group } from '@mantine/core';
+import { Funnel, Check, Wrench, Shield, FolderKanban, ListFilter } from 'lucide-react';
 
 export default function FiltersNotices() {
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const currentCategory = searchParams.get("category") || "";
-  const currentSort = searchParams.get("sort") || "newest";
+  const currentCategory = searchParams.get('category') || '';
+  const currentSort = searchParams.get('sort') || 'newest';
 
   const updateFilter = (key: string, value: string | null) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -17,7 +17,7 @@ export default function FiltersNotices() {
     if (value === null) params.delete(key);
     else params.set(key, value);
 
-    params.delete("page");
+    params.delete('page');
 
     router.push(`?${params.toString()}`);
   };
@@ -44,30 +44,55 @@ export default function FiltersNotices() {
   return (
     <Menu width={220} position="bottom-end" shadow="md" radius="md">
       <Menu.Target>
-        <Button
-          variant="outline"
-          color="blue"
-          size="sm"
-          leftSection={<Funnel size={16} />}
-        >
-          Filter
+        <Button variant="outline" color="blue" size="sm" leftSection={<Funnel size={16} />}>
+          Filters
         </Button>
       </Menu.Target>
 
       <Menu.Dropdown>
         <Menu.Label style={{ fontSize: 13, opacity: 0.8 }}>Category</Menu.Label>
 
-        {MenuItem("All", null, <ListFilter size={16} />, currentCategory === "", "category")}
-        {MenuItem("Maintenance", "Maintenance", <Wrench size={16} />, currentCategory === "Maintenance", "category")}
-        {MenuItem("Safety", "Safety", <Shield size={16} />, currentCategory === "Safety", "category")}
-        {MenuItem("General", "General", <FolderKanban size={16} />, currentCategory === "General", "category")}
+        {MenuItem('All', null, <ListFilter size={16} />, currentCategory === '', 'category')}
+        {MenuItem(
+          'Maintenance',
+          'Maintenance',
+          <Wrench size={16} />,
+          currentCategory === 'Maintenance',
+          'category'
+        )}
+        {MenuItem(
+          'Safety',
+          'Safety',
+          <Shield size={16} />,
+          currentCategory === 'Safety',
+          'category'
+        )}
+        {MenuItem(
+          'General',
+          'General',
+          <FolderKanban size={16} />,
+          currentCategory === 'General',
+          'category'
+        )}
 
         <Menu.Divider />
 
         <Menu.Label style={{ fontSize: 13, opacity: 0.8 }}>Sort by date</Menu.Label>
 
-        {MenuItem("Newest first", "newest", <ListFilter size={16} />, currentSort === "newest", "sort")}
-        {MenuItem("Oldest first", "oldest", <ListFilter size={16} />, currentSort === "oldest", "sort")}
+        {MenuItem(
+          'Newest first',
+          'newest',
+          <ListFilter size={16} />,
+          currentSort === 'newest',
+          'sort'
+        )}
+        {MenuItem(
+          'Oldest first',
+          'oldest',
+          <ListFilter size={16} />,
+          currentSort === 'oldest',
+          'sort'
+        )}
       </Menu.Dropdown>
     </Menu>
   );


### PR DESCRIPTION
Closes #101 

- Introduced badges to display active category and sort filters on both Admin and Resident Notices pages.
- Improved code formatting and consistency

Implemented badges
<img width="207" height="88" alt="Screenshot 2025-11-28 at 14 57 20" src="https://github.com/user-attachments/assets/6c9d0e21-7b16-43ff-b24d-1fe00e7043d5" />


**User Panel**
<img width="1200" height="789" alt="Screenshot 2025-11-28 at 14 56 12" src="https://github.com/user-attachments/assets/5f5f26b1-29ce-440c-bd73-44309a51b9eb" />

**Admin Panel**
<img width="1200" height="789" alt="Screenshot 2025-11-28 at 14 56 36" src="https://github.com/user-attachments/assets/62a1c179-ada5-4ca0-ab04-3c81ad4c1b21" />
