### PR TITLE
feat(creat-worry):add notification system to Create-Worry Form

### DIFF
--- a/app/protected/Resident/Create-Worry/components/CreateWorryForm.tsx
+++ b/app/protected/Resident/Create-Worry/components/CreateWorryForm.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import "@mantine/core/styles.css";
+import '@mantine/core/styles.css';
 import {
   TextInput,
   Textarea,
@@ -10,27 +10,28 @@ import {
   Title,
   Stack,
   Text,
-  LoadingOverlay
-} from "@mantine/core";
+  LoadingOverlay,
+} from '@mantine/core';
 
-import { useTransition, useState } from "react";
-import { createWorry } from "../actions";
-import { FileText } from "lucide-react";
+import { useTransition, useState } from 'react';
+import { createWorry } from '../actions';
+import { FileText } from 'lucide-react';
+import { notifications } from '@mantine/notifications';
 
 export default function CreateNoticeForm() {
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
-  const [title, setTitle] = useState("");
-  const [content, setContent] = useState("");
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
 
   function validate(formData: FormData) {
-    const title = String(formData.get("title") ?? "").trim();
-    const content = String(formData.get("content") ?? "").trim();
+    const title = String(formData.get('title') ?? '').trim();
+    const content = String(formData.get('content') ?? '').trim();
 
-    if (!title) return "Title is required.";
-    if (!content) return "Description is required.";
-    if (title.length > 200) return "Title is too long.";
+    if (!title) return 'Title is required.';
+    if (!content) return 'Description is required.';
+    if (title.length > 200) return 'Title is too long.';
 
     return null;
   }
@@ -41,38 +42,57 @@ export default function CreateNoticeForm() {
 
     const formData = new FormData(e.currentTarget);
     const validationError = validate(formData);
+
     if (validationError) {
-      setError(validationError);
+      notifications.show({
+        title: 'Error',
+        message: validationError,
+        color: 'red',
+      });
       return;
     }
 
     const form = e.currentTarget;
 
     form.reset();
-    setTitle("");
-    setContent("");
+    setTitle('');
+    setContent('');
 
     startTransition(async () => {
       try {
         await createWorry(formData);
+
+        notifications.show({
+          title: 'Created Worry',
+          message: 'Worry created successfully!',
+          color: 'green',
+        });
       } catch (err) {
         if (err instanceof Error) {
           const map: Record<string, string> = {
-            ERROR_NO_TITLE: "Title is required.",
-            ERROR_TITLE_TOO_LONG: "Title is too long.",
-            ERROR_DESCRIPTION_TOO_LONG: "Description is too long.",
-            ERROR_UNAUTHORIZED: "You are not authorized.",
-            ERROR_USER_HAS_NO_COMMUNITY:
-              "You are not assigned to a community.",
-            ERROR_DB_INSERT_FAILED: "Failed to save the notice.",
-            ERROR_FETCHING_PROFILE: "Cannot load profile.",
-            ERROR_UNKNOWN: "Unexpected server error."
+            ERROR_NO_TITLE: 'Title is required.',
+            ERROR_TITLE_TOO_LONG: 'Title is too long.',
+            ERROR_DESCRIPTION_TOO_LONG: 'Description is too long.',
+            ERROR_UNAUTHORIZED: 'You are not authorized.',
+            ERROR_USER_HAS_NO_COMMUNITY: 'You are not assigned to a community.',
+            ERROR_DB_INSERT_FAILED: 'Failed to save the notice.',
+            ERROR_FETCHING_PROFILE: 'Cannot load profile.',
+            ERROR_UNKNOWN: 'Unexpected server error.',
           };
 
-          const message = map[err.message] ?? "Unexpected server error.";
-          setError(message);
+          const message = map[err.message] ?? 'Unexpected server error.';
+
+          notifications.show({
+            title: 'Error',
+            message: message,
+            color: 'red',
+          });
         } else {
-          setError("Unexpected server error.");
+          notifications.show({
+            title: 'Unexpected Error',
+            message: 'Unexpected server error. Please try again later.',
+            color: 'red',
+          });
         }
       }
     });
@@ -84,10 +104,10 @@ export default function CreateNoticeForm() {
       padding="xl"
       withBorder
       style={{
-        width: "100%",
+        width: '100%',
         maxWidth: 650,
-        margin: "0 auto",
-        position: "relative"
+        margin: '0 auto',
+        position: 'relative',
       }}
     >
       <LoadingOverlay visible={isPending} zIndex={20} />
@@ -95,12 +115,6 @@ export default function CreateNoticeForm() {
       <Title order={2} mb="lg">
         Create a Worry
       </Title>
-
-      {error && (
-        <Text c="red" mb="sm" size="sm">
-          {error}
-        </Text>
-      )}
 
       <form onSubmit={handleSubmit}>
         <Stack gap="md">


### PR DESCRIPTION
Closes #107 

- Added Mantine notifications for handling successes and errors.
- Formatted code.

<img width="1200" height="699" alt="Screenshot 2025-11-28 at 23 21 50" src="https://github.com/user-attachments/assets/d8be8c87-58dd-4529-a333-11c5aef52e8a" />
