### PR TITLE
fix(worries): fix format worry creation dates in both roles

### DIFF
--- a/app/protected/Admin/Worries/page.tsx
+++ b/app/protected/Admin/Worries/page.tsx
@@ -20,7 +20,6 @@ export default function AdminWorriesPage() {
   const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  
   const itemsPerPage = 3;
 
   const buildPageUrl = (newPage: number) => {
@@ -45,16 +44,13 @@ export default function AdminWorriesPage() {
   }, [page, sort, itemsPerPage]);
 
   const handleDelete = async (id: string) => {
-    const confirmed = window.confirm(
-      'Are you sure you want to delete this worry?',
-    );
+    const confirmed = window.confirm('Are you sure you want to delete this worry?');
     if (!confirmed) return;
 
     setDeletingId(id);
 
     try {
       await deleteWorry(id);
-      
       await fetchWorries();
 
       if (worries.length === 1 && page > 1) {
@@ -62,7 +58,6 @@ export default function AdminWorriesPage() {
         setPage(newPage);
         router.push(buildPageUrl(newPage));
       }
-
     } catch (error: unknown) {
       console.error('Error deleting worry:', error);
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -99,7 +94,6 @@ export default function AdminWorriesPage() {
           </Text>
           <FiltersWorries />
         </Flex>
-        
         <Flex gap="xs" mt={-4} justify="flex-end" align="center" w="100%">
           <Badge
             color="blue"
@@ -118,42 +112,53 @@ export default function AdminWorriesPage() {
           </Text>
         )}
 
-        {worries.map((worry) => (
-          <Card key={worry.id} withBorder shadow="sm" radius="md">
-            <Group justify="space-between" align="flex-start" mb="xs">
-              <Stack gap={2}>
-                <Text fw={600}>{worry.title || 'Untitled worry'}</Text>
+        {worries.map((worry) => {
+          const date = new Date(worry.created_at + 'Z');
+          const formattedDate = date.toLocaleDateString('en-GB', {
+            day: '2-digit',
+            month: 'short',
+            year: 'numeric'
+          });
+          const formattedTime = date.toLocaleTimeString('en-GB', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false
+          });
 
-                <Text size="sm" c="dimmed">
-                  {worry.created_by
-                    ? `Created by ${worry.created_by}`
-                    : 'Created by resident'}
+          return (
+            <Card key={worry.id} withBorder shadow="sm" radius="md">
+              <Group justify="space-between" align="flex-start" mb="xs">
+                <Stack gap={2}>
+                  <Text fw={600}>{worry.title || 'Untitled worry'}</Text>
+
+                  <Text size="sm" c="dimmed">
+                    {worry.created_by ? `Created by ${worry.created_by}` : 'Created by resident'}
+                  </Text>
+
+                  <Text size="xs" c="dimmed">
+                    {formattedDate}, {formattedTime}
+                  </Text>
+                </Stack>
+
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => handleDelete(worry.id)}
+                  disabled={deletingId === worry.id}
+                >
+                  {deletingId === worry.id ? 'Deleting…' : 'Delete'}
+                </Button>
+              </Group>
+
+              {worry.content && (
+                <Text size="sm" mt="xs">
+                  {worry.content}
                 </Text>
+              )}
+            </Card>
+          );
+        })}
 
-                <Text size="xs" c="dimmed">
-                  {new Date(worry.created_at).toLocaleString()}
-                </Text>
-              </Stack>
-
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => handleDelete(worry.id)}
-                disabled={deletingId === worry.id}
-              >
-                {deletingId === worry.id ? 'Deleting…' : 'Delete'}
-              </Button>
-            </Group>
-
-            {worry.content && (
-              <Text size="sm" mt="xs">
-                {worry.content}
-              </Text>
-            )}
-          </Card>
-        ))}
-
-        {/* Pagination */}
         {worries.length > 0 && (
           <Group justify="center" mt="md" gap="md">
             {page > 1 && (

--- a/app/protected/Resident/Worries/page.tsx
+++ b/app/protected/Resident/Worries/page.tsx
@@ -27,7 +27,7 @@ export default function ResidentWorriesPage() {
   const [worries, setWorries] = useState<Worry[]>([]);
   const [loading, setLoading] = useState(true);
   const [count, setCount] = useState(0);
-  
+
   const itemsPerPage = 3;
 
   const buildPageUrl = (newPage: number) => {
@@ -44,8 +44,10 @@ export default function ResidentWorriesPage() {
         const from = (page - 1) * itemsPerPage;
         const to = from + itemsPerPage - 1;
 
-        const { data: { user } } = await supabase.auth.getUser();
-        
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
         if (!user) {
           setWorries([]);
           setCount(0);
@@ -67,7 +69,7 @@ export default function ResidentWorriesPage() {
         const { data, error, count } = await supabase
           .from('worries')
           .select('id, title, content, created_at', { count: 'exact' })
-          .eq('community_id', profile.community_id) 
+          .eq('community_id', profile.community_id)
           .order('created_at', { ascending: sort === 'oldest' })
           .range(from, to);
 
@@ -132,21 +134,35 @@ export default function ResidentWorriesPage() {
           </Text>
         )}
 
-        {worries.map((worry) => (
-          <Card key={worry.id} withBorder shadow="sm" radius="md">
-            <Text fw={600}>{worry.title || 'Untitled worry'}</Text>
+        {worries.map((worry) => {
+          const date = new Date(worry.created_at + 'Z');
+          const formattedDate = date.toLocaleDateString('en-GB', {
+            day: '2-digit',
+            month: 'short',
+            year: 'numeric',
+          });
+          const formattedTime = date.toLocaleTimeString('en-GB', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+          });
 
-            {worry.content && (
-              <Text size="sm" mt="xs">
-                {worry.content}
+          return (
+            <Card key={worry.id} withBorder shadow="sm" radius="md">
+              <Text fw={600}>{worry.title || 'Untitled worry'}</Text>
+
+              {worry.content && (
+                <Text size="sm" mt="xs">
+                  {worry.content}
+                </Text>
+              )}
+
+              <Text size="xs" c="dimmed" mt="xs">
+                {formattedDate}, {formattedTime}
               </Text>
-            )}
-
-            <Text size="xs" c="dimmed" mt="xs">
-              {new Date(worry.created_at).toLocaleString()}
-            </Text>
-          </Card>
-        ))}
+            </Card>
+          );
+        })}
 
         {/* Pagination */}
         {worries.length > 0 && (


### PR DESCRIPTION
Closes #109

- Updated worry creation dates in Admin and Resident pages to use consistent en-GB formatted date and time for better readability.

**User panel**
<img width="1200" height="135" alt="Screenshot 2025-12-01 at 17 34 27" src="https://github.com/user-attachments/assets/1656c774-0be3-48a8-ac40-5d9a5c1ac827" />
**Admin panel**
<img width="1200" height="157" alt="Screenshot 2025-12-01 at 17 34 50" src="https://github.com/user-attachments/assets/582f1940-3915-492e-bd58-c0460bd31271" />
