### PR TITLE
feat(auth): add approval and reject action

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -17,6 +17,7 @@ export async function POST(req: Request) {
       houseNumber, 
       city, 
       country 
+      country
     } = body;
 
     if (!email || !password || !fullName || !flatNumber || !ads_oid) {
@@ -95,6 +96,7 @@ export async function POST(req: Request) {
       flat_number: flatNumber,
       community_id: community.id, 
       role: "resident",
+      status: "pending",
     });
 
     if (insertError) {

--- a/app/protected/Admin/Residents/actions.tsx
+++ b/app/protected/Admin/Residents/actions.tsx
@@ -1,0 +1,29 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { revalidatePath } from 'next/cache';
+
+export async function removeResidentAction(id: string) {
+  const supabase = await createClient();
+
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth?.user) throw new Error('ERROR_UNAUTHORIZED_USER');
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('community_id')
+    .eq('id', auth.user.id)
+    .single();
+
+  if (!profile?.community_id) throw new Error('ERROR_UNAUTHORIZED_COMMUNITY');
+
+  const { error } = await supabase
+    .from('users')
+    .delete()
+    .eq('id', id)
+    .eq('community_id', profile.community_id);
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath('/protected/Admin/Residents');
+}

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -1,128 +1,131 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import Link from "next/link";
-import { EstonianAddress, EstonianAddressData } from "@/components/estonian-address";
-import { createClient } from "@/lib/supabase/client";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import Link from 'next/link';
+import { EstonianAddress, EstonianAddressData } from '@/components/estonian-address';
+import { createClient } from '@/lib/supabase/client';
 
 export function SignUpForm() {
-const router = useRouter();
+  const router = useRouter();
 
-const [fullName, setFullName] = useState("");
-const [email, setEmail] = useState("");
-const [password, setPassword] = useState("");
-const [repeatPassword, setRepeatPassword] = useState("");
-const [flatNumber, setFlatNumber] = useState("");
-const [selectedAddress, setSelectedAddress] = useState<EstonianAddressData | null>(null);
-const [error, setError] = useState<string | null>(null);
-const [isLoading, setIsLoading] = useState(false);
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [repeatPassword, setRepeatPassword] = useState('');
+  const [flatNumber, setFlatNumber] = useState('');
+  const [selectedAddress, setSelectedAddress] = useState<EstonianAddressData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
-const handleSignUp = async (e: React.FormEvent) => {
-e.preventDefault();
-setError(null);
+  const handleSignUp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
 
-if (!selectedAddress) {
-setError("Please select your address");
-return;
-}
-if (password !== repeatPassword) {
-setError("Passwords do not match");
-return;
-}
-if (password.length < 8 || !/\d/.test(password) || !/[A-Za-z]/.test(password)) {
-setError("Password must be at least 8 characters and contain letters and numbers");
-return;
-}
+    if (!selectedAddress) {
+      setError('Please select your address');
+      return;
+    }
+    if (password !== repeatPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    if (password.length < 8 || !/\d/.test(password) || !/[A-Za-z]/.test(password)) {
+      setError('Password must be at least 8 characters and contain letters and numbers');
+      return;
+    }
 
-setIsLoading(true);
+    setIsLoading(true);
 
-try {
-const response = await fetch("/api/register", {
-method: "POST",
-headers: { "Content-Type": "application/json" },
-body: JSON.stringify({
-email,
-password,
-fullName,
-flatNumber,
-ads_oid: selectedAddress.ads_oid,
-full_address: selectedAddress.full_address,
-streetName: selectedAddress.streetName,
-houseNumber: selectedAddress.houseNumber,
-city: selectedAddress.city,
-country: selectedAddress.country,
-}),
-});
+    try {
+      const response = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          password,
+          fullName,
+          flatNumber,
+          ads_oid: selectedAddress.ads_oid,
+          full_address: selectedAddress.full_address,
+          streetName: selectedAddress.streetName,
+          houseNumber: selectedAddress.houseNumber,
+          city: selectedAddress.city,
+          country: selectedAddress.country,
+        }),
+      });
 
-const data = await response.json();
-if (!response.ok) throw new Error(data.error || "Registration failed");
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Registration failed');
+      router.push('/auth/login?pending=1');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-const supabase = createClient(); 
-const { error: loginError } = await supabase.auth.signInWithPassword({
-  email,
-  password,
-});
-if (loginError) throw loginError;
+  return (
+    <Card className="max-w-md mx-auto mt-20">
+      <CardHeader>
+        <CardTitle>Sign Up</CardTitle>
+        <CardDescription>Create a new account (Resident only)</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSignUp} className="flex flex-col gap-4">
+          <div>
+            <Label>Full Name</Label>
+            <Input value={fullName} onChange={(e) => setFullName(e.target.value)} required />
+          </div>
+          <div>
+            <Label>Email</Label>
+            <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+          </div>
+          <div>
+            <Label>Password</Label>
+            <Input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label>Repeat Password</Label>
+            <Input
+              type="password"
+              value={repeatPassword}
+              onChange={(e) => setRepeatPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div className="relative z-10">
+            <Label>Select your address</Label>
+            <EstonianAddress onSelect={setSelectedAddress} height="410px" />
+          </div>
+          <div>
+            <Label>Flat Number</Label>
+            <Input value={flatNumber} onChange={(e) => setFlatNumber(e.target.value)} required />
+          </div>
 
-const communityId = data.communityId;
-router.push(`/protected/Resident/Notices?communityId=${communityId}`);
+          {error && <p className="text-red-500 text-sm">{error}</p>}
 
-} catch (err: unknown) {
-setError(err instanceof Error ? err.message : "An error occurred");
-} finally {
-setIsLoading(false);
-}
-};
+          <Button type="submit" disabled={isLoading || !selectedAddress}>
+            {isLoading ? 'Creating account...' : 'Sign Up'}
+          </Button>
+        </form>
 
-return (
-  <Card className="max-w-md mx-auto mt-20">
-    <CardHeader>
-      <CardTitle>Sign Up</CardTitle>
-      <CardDescription>Create a new account (Resident only)</CardDescription>
-    </CardHeader>
-    <CardContent>
-      <form onSubmit={handleSignUp} className="flex flex-col gap-4">
-        <div>
-          <Label>Full Name</Label>
-          <Input value={fullName} onChange={(e) => setFullName(e.target.value)} required />
+        <div className="mt-4 text-center text-sm">
+          Already have an account?{' '}
+          <Link href="/auth/login" className="underline">
+            Log in
+          </Link>
         </div>
-        <div>
-          <Label>Email</Label>
-          <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-        </div>
-        <div>
-          <Label>Password</Label>
-          <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-        </div>
-        <div>
-          <Label>Repeat Password</Label>
-          <Input type="password" value={repeatPassword} onChange={(e) => setRepeatPassword(e.target.value)} required />
-        </div>
-        <div className="relative z-10">
-          <Label>Select your address</Label>
-          <EstonianAddress onSelect={setSelectedAddress} height="410px" />
-        </div>
-        <div>
-          <Label>Flat Number</Label>
-          <Input value={flatNumber} onChange={(e) => setFlatNumber(e.target.value)} required />
-        </div>
-
-        {error && <p className="text-red-500 text-sm">{error}</p>}
-
-        <Button type="submit" disabled={isLoading || !selectedAddress}>
-          {isLoading ? "Creating account..." : "Sign Up"}
-        </Button>
-      </form>
-
-      <div className="mt-4 text-center text-sm">
-        Already have an account? <Link href="/auth/login" className="underline">Log in</Link>
-      </div>
-    </CardContent>
-  </Card>
-);
+      </CardContent>
+    </Card>
+  );
 }


### PR DESCRIPTION
Closes #88

- Add pending status for new residents and block login until approval
- Remove rejected users to allow re-registration
- Update admin residents page with approve and reject actions
- Improve user feedback during login and signup
- Format the code

**After signing up**
<img width="450" height="432" alt="Screenshot_2025-12-01_at_21 19 45" src="https://github.com/user-attachments/assets/544b20a5-6edc-4d9e-a8ef-4443a6af214c" />
**When user is pending** 
<img width="450" height="980" alt="image" src="https://github.com/user-attachments/assets/1bc88bd3-ff14-4c27-9409-cbc1be752c66" />
**After signing up and when user is pending**
<img width="450" height="1178" alt="image" src="https://github.com/user-attachments/assets/21f4204e-53c9-4d59-9a3d-dbb81fefd302" />
