### PR TITLE
feat(admin): add solution for deleting users with related worries

### DIFF
--- a/app/protected/Admin/Residents/actions.tsx
+++ b/app/protected/Admin/Residents/actions.tsx
@@ -17,6 +17,8 @@ export async function removeResidentAction(id: string) {
 
   if (!profile?.community_id) throw new Error('ERROR_UNAUTHORIZED_COMMUNITY');
 
+  await supabase.from('worries').delete().eq('created_by', id);
+
   const { error } = await supabase
     .from('users')
     .delete()


### PR DESCRIPTION
Closes #122

<img width="1053" height="105" alt="image" src="https://github.com/user-attachments/assets/1237a9a6-f2d8-44cb-a81b-21144322d296" />


- Deletes all worries created by a user before deleting the user
- Adds RLS policy to allow admins to delete users with related worries
- Updates removeResidentAction to handle dependent worries correctly