### PR TITLE
feat(admin/notices): add user-friendly confirmation modal for delete actions #59

### DIFF
--- a/app/protected/Admin/Notices/components/DeleteButtonMeeting.tsx
+++ b/app/protected/Admin/Notices/components/DeleteButtonMeeting.tsx
@@ -1,37 +1,49 @@
 'use client';
+
+import { useState, useTransition } from 'react';
 import { Button } from '@mantine/core';
 import { Trash } from 'lucide-react';
+import ConfirmModal from '@/components/ui/ConfirmModal';
 import { deleteMeeting } from '@/app/protected/Admin/Notices/actions';
-import { useTransition } from 'react';
 
 interface Props {
   id: string;
-  onClick?: () => void; 
+  onClick?: () => void;
 }
 
 export default function DeleteButtonMeeting({ id, onClick }: Props) {
+  const [opened, setOpened] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const handleDelete = async () => {
-    const confirmed = confirm('Are you sure you want to delete this meeting?');
-    if (!confirmed) return;
+  const handleConfirm = () => {
     startTransition(async () => {
       await deleteMeeting(id);
-      onClick?.(); 
+      onClick?.();
+      setOpened(false);
     });
   };
 
   return (
-    <Button
-      variant="light"
-      color="red"
-      radius="xl"
-      size="compact-sm"
-      leftSection={<Trash size={14} />}
-      onClick={handleDelete}
-      disabled={isPending}
-    >
-      {isPending ? 'Deleting...' : 'Delete'}
-    </Button>
+    <>
+      <Button
+        variant="light"
+        color="red"
+        radius="xl"
+        size="compact-sm"
+        leftSection={<Trash size={14} />}
+        onClick={() => setOpened(true)}
+      >
+        Delete
+      </Button>
+
+      <ConfirmModal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        onConfirm={handleConfirm}
+        loading={isPending}
+        title="Delete meeting"
+        message="Are you sure you want to delete this meeting?"
+      />
+    </>
   );
 }

--- a/app/protected/Admin/Notices/components/DeleteButtonNotice.tsx
+++ b/app/protected/Admin/Notices/components/DeleteButtonNotice.tsx
@@ -1,37 +1,49 @@
 'use client';
+
+import { useState, useTransition } from 'react';
 import { Button } from '@mantine/core';
 import { Trash } from 'lucide-react';
+import ConfirmModal from '@/components/ui/ConfirmModal';
 import { deleteNotice } from '@/app/protected/Admin/Notices/actions';
-import { useTransition } from 'react';
 
 interface Props {
   id: string;
-  onClick?: () => void; // 
+  onClick?: () => void;
 }
 
 export default function DeleteButtonNotice({ id, onClick }: Props) {
+  const [opened, setOpened] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const handleDelete = async () => {
-    const confirmed = confirm('Are you sure you want to delete this notice?');
-    if (!confirmed) return;
+  const handleConfirm = () => {
     startTransition(async () => {
       await deleteNotice(id);
-      onClick?.(); 
+      onClick?.();
+      setOpened(false);
     });
   };
 
   return (
-    <Button
-      variant="light"
-      color="red"
-      radius="xl"
-      size="compact-sm"
-      leftSection={<Trash size={14} />}
-      onClick={handleDelete}
-      disabled={isPending}
-    >
-      {isPending ? 'Deleting...' : 'Delete'}
-    </Button>
+    <>
+      <Button
+        variant="light"
+        color="red"
+        radius="xl"
+        size="compact-sm"
+        leftSection={<Trash size={14} />}
+        onClick={() => setOpened(true)}
+      >
+        Delete
+      </Button>
+
+      <ConfirmModal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        onConfirm={handleConfirm}
+        loading={isPending}
+        title="Delete notice"
+        message="Are you sure you want to delete this notice?"
+      />
+    </>
   );
 }

--- a/components/ui/ConfirmModal.tsx
+++ b/components/ui/ConfirmModal.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Modal, Text, Group, Button } from '@mantine/core';
+
+interface ConfirmModalProps {
+  opened: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title?: string;
+  message?: string;
+  loading?: boolean;
+}
+
+export default function ConfirmModal({
+  opened,
+  onClose,
+  onConfirm,
+  title = 'Are you sure?',
+  message = 'This action cannot be undone.',
+  loading = false,
+}: ConfirmModalProps) {
+  return (
+    <Modal opened={opened} onClose={onClose} title={title} centered>
+      <Text size="sm" mb="md">
+        {message}
+      </Text>
+
+      <Group justify="flex-end">
+        <Button variant="default" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button color="red" onClick={onConfirm} loading={loading}>
+          Confirm
+        </Button>
+      </Group>
+    </Modal>
+  );
+}


### PR DESCRIPTION


Replaced native browser `confirm()` dialogs with a reusable, more user-friendly confirmation modal component. Applied new modal to both Notice and Meeting delete flows inside the Admin panel.

Improved UX by providing consistent UI, better feedback, and safer delete interaction patterns.

Only Worries section left to update with the new modal component.

closes 59