### PR TITLE
fix(notices): unify NoticeCard sizing and spacing for consistent layout(#132)

### DIFF
--- a/components/NoticeCard.tsx
+++ b/components/NoticeCard.tsx
@@ -75,12 +75,8 @@ export default function NoticeCard({ notice, role, onUpdate, onDelete, onAfterSa
 
   return (
     <>
-<<<<<<< Updated upstream
-      <Card radius="md" padding="sm" withBorder style={{ maxWidth: 600, margin: '18px auto' }}>
-=======
       {/* width fixed to 100%, spacing handled by parent via gap */}
       <Card radius="md" padding="lg" withBorder shadow="sm" style={{ width: '100%' }}>
->>>>>>> Stashed changes
         <Group justify="space-between" mb="xs">
           <Badge color={badgeColor} size="sm" variant="filled">
             {notice.category}


### PR DESCRIPTION


Adjusted NoticeCard styling to ensure all cards have equal width and aligned layout. Removed inconsistent auto margins and corrected spacing so admin notice cards render uniformly.

closes #132