### PR TITLE
fix(worries): show user full name instead of user ID on Worries page 

### DIFF
--- a/app/protected/Admin/Worries/actions.ts
+++ b/app/protected/Admin/Worries/actions.ts
@@ -26,40 +26,49 @@ export async function getWorries(
     const from = (page - 1) * limit;
     const to = from + limit - 1;
 
+    // join worries -> users (created_by -> users.id) to get full_name
     let query = supabase
-  .from('worries')
-  .select(
-    `
-    id,
-    title,
-    content,
-    created_at,
-    created_by,
-    community_id,
-    likesworry (
-      id,
-      user_id
-    )
-  `,
-    { count: 'exact' }
-  )
-  .eq('community_id', profile.community_id);
+      .from('worries')
+      .select(
+        `
+        id,
+        title,
+        content,
+        created_at,
+        created_by,
+        community_id,
+        likesworry (
+          id,
+          user_id
+        ),
+        user:created_by (
+          full_name
+        )
+      `,
+        { count: 'exact' }
+      )
+      .eq('community_id', profile.community_id);
 
-query = query.order('created_at', { ascending: sort === 'oldest' });
+    query = query.order('created_at', { ascending: sort === 'oldest' });
 
-const { data, count, error } = await query.range(from, to);
-if (error) throw error;
+    const { data, count, error } = await query.range(from, to);
+    if (error) throw error;
 
-const worries: Worry[] =
-  (data ?? []).map((row: any) => {
-    const likes = row.likesworry ?? [];
-    const likesCount = likes.length;
+    const worries: Worry[] =
+      (data ?? []).map((row: any) => {
+        const likes = row.likesworry ?? [];
+        const likesCount = likes.length;
+        const creator_name = row.user?.full_name ?? null;
 
-    const { likesworry, ...rest } = row;
-    return { ...rest, likesCount } as Worry;
-  });
+        const { likesworry, user, ...rest } = row;
+        return {
+          ...rest,
+          likesCount,
+          creator_name,
+        } as Worry;
+      });
 
-return { data: worries, count: count ?? 0 };
+    return { data: worries, count: count ?? 0 };
   } catch (err) {
     console.error('Error fetching worries:', err);
     return { data: [], count: 0 };
@@ -68,16 +77,16 @@ return { data: worries, count: count ?? 0 };
 
 export async function deleteWorry(id: string) {
   const supabase = await createClient();
-  
+
   const { data: auth } = await supabase.auth.getUser();
   if (!auth?.user) throw new Error('ERROR_UNAUTHORIZED_USER');
-  
+
   const { data: profile } = await supabase
     .from('users')
     .select('community_id')
     .eq('id', auth.user.id)
     .single();
-  
+
   if (!profile?.community_id) throw new Error('ERROR_UNAUTHORIZED_COMMUNITY');
 
   const { error } = await supabase

--- a/app/protected/Admin/Worries/page.tsx
+++ b/app/protected/Admin/Worries/page.tsx
@@ -149,14 +149,17 @@ export default function AdminWorriesPage() {
                 <Group justify="space-between" align="flex-start" mb="xs">
                   <Stack gap={2}>
                     <Text fw={600}>{worry.title || 'Untitled worry'}</Text>
+
                     <Text size="sm" c="dimmed">
-                      {worry.created_by
-                        ? `Created by ${worry.created_by}`
+                      {worry.creator_name
+                        ? `Created by ${worry.creator_name}`
                         : 'Created by resident'}
                     </Text>
+
                     <Text size="xs" c="dimmed">
                       {formattedDate}, {formattedTime}
                     </Text>
+
                     <Text size="xs" c="dimmed">
                       Likes: {worry.likesCount ?? 0}
                     </Text>

--- a/types/Worry.ts
+++ b/types/Worry.ts
@@ -5,10 +5,13 @@ export type Worry = {
   title: string | null;
   content: string | null;
   created_at: string;
-  created_by?: string | null;
-  community_id?: CommunityId | null;
+
+  created_by: string | null;          // user id
+  community_id?: string | null;
 
   // likes
-  likesCount?: number;   // how many likes this worry has
-  hasLiked?: boolean;    // whether current user has liked it
+  likesCount?: number;
+  hasLiked?: boolean;
+
+  creator_name?: string | null;
 };


### PR DESCRIPTION
Joined users table when fetching worries and updated UI to display creator’s full name instead of internal user identifier.

closes #81