### PR TITLE
fix(register): remove duplicate country field causing build failure 

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -16,8 +16,8 @@ export async function POST(req: Request) {
       streetName, 
       houseNumber, 
       city, 
-      country 
       country
+
     } = body;
 
     if (!email || !password || !fullName || !flatNumber || !ads_oid) {


### PR DESCRIPTION
closes #136


Removed an unnecessary duplicated field in register/route.ts.Now there’s no error, it works .