### PR TITLE
feat(navbars):add community to navbars for both roles

### DIFF
--- a/app/protected/Admin/layout.tsx
+++ b/app/protected/Admin/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { MantineProvider } from '@mantine/core';
 import '@mantine/core/styles.css';
-import { AdminNavbar } from '@/components/NavBar/AdminNavbar';
+import AdminNavbarWrapper  from '@/components/NavBar/AdminNavbarWrapper';
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <MantineProvider theme={{ fontFamily: 'Inter, sans-serif' }}>
-      <AdminNavbar />
+      <AdminNavbarWrapper />
       {children}
     </MantineProvider>
   );

--- a/app/protected/Resident/layout.tsx
+++ b/app/protected/Resident/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { MantineProvider } from '@mantine/core';
 import '@mantine/core/styles.css';
-import { UserNavbar } from '@/components/NavBar/UserNavbar';
+import UserNavbarWrapper from '@/components/NavBar/UserNavbarWrapper';
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <MantineProvider theme={{ fontFamily: 'Inter, sans-serif' }}>
-      <UserNavbar />
+      <UserNavbarWrapper />
       {children}
     </MantineProvider>
   );

--- a/components/NavBar/AdminNavbar.tsx
+++ b/components/NavBar/AdminNavbar.tsx
@@ -1,19 +1,23 @@
 'use client';
 
 import { usePathname, useRouter } from 'next/navigation';
-import { Button, Group, Container, Paper } from '@mantine/core';
+import { Button, Group, Container, Paper, Tooltip, Text, Badge } from '@mantine/core';
 import { LogoutButton } from '@/components/logout-button';
 
-export function AdminNavbar() {
+type CommunityProps = {
+  community: { id: string; full_address: string } | null;
+};
+
+export function AdminNavbar({ community }: CommunityProps) {
   const router = useRouter();
   const pathname = usePathname();
 
   const links = [
     { href: '/protected/Admin/Notices', label: 'Notices' },
-    { href: '/protected/Admin/Worries', label: 'Worries' }, 
+    { href: '/protected/Admin/Worries', label: 'Worries' },
     { href: '/protected/Admin/Residents', label: 'Residents' },
     { href: '/protected/Admin/Create-Meetings', label: 'Create Meetings' },
-    { href: '/protected/Admin/CreateNotice', label: 'Create Notice' }, //url needs to be changed to create notice page, there is needs to be such a folder for it.
+    { href: '/protected/Admin/CreateNotice', label: 'Create Notice' },
   ];
 
   return (
@@ -35,12 +39,34 @@ export function AdminNavbar() {
               );
             })}
           </Group>
+          <Group wrap="nowrap" gap="xs" justify="center" align="center">
+            <Tooltip
+              label={community?.full_address}
+              withArrow
+              color="rgba(0, 0, 0, 0.4)"
+              multiline
+              w={220}
+              position="bottom"
+            >
+              <Badge
+                variant="light"
+                title=""
+                style={{
+                  maxWidth: '220px',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  display: 'inline-block',
+                }}
+              >
+                {community?.full_address}
+              </Badge>
+            </Tooltip>
 
-          <LogoutButton />
+            <LogoutButton />
+          </Group>
         </Group>
       </Container>
     </Paper>
   );
 }
-
-

--- a/components/NavBar/AdminNavbarWrapper.tsx
+++ b/components/NavBar/AdminNavbarWrapper.tsx
@@ -1,0 +1,12 @@
+import { getCommunityInfo } from './getCommunityInfo';
+import { AdminNavbar } from './AdminNavbar';
+
+export default async function AdminNavbarWrapper() {
+  const community = await getCommunityInfo();
+
+  return (
+    <>
+      <AdminNavbar community={community} />
+    </>
+  );
+}

--- a/components/NavBar/UserNavbar.tsx
+++ b/components/NavBar/UserNavbar.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { usePathname, useRouter } from 'next/navigation';
-import { Group, Container, Paper } from '@mantine/core';
+import { Group, Container, Paper, Badge, Tooltip } from '@mantine/core';
 import { Button } from '@/components/ui/button';
 import { LogoutButton } from '@/components/logout-button';
 
-export function UserNavbar() {
+type CommunityProps = {
+  community: { id: string; full_address: string } | null;
+};
+
+export function UserNavbar({ community }: CommunityProps) {
   const router = useRouter();
   const pathname = usePathname();
 
@@ -34,8 +38,32 @@ export function UserNavbar() {
               );
             })}
           </Group>
+          <Group wrap="nowrap" gap="xs" justify="center" align="center">
+            <Tooltip
+              label={community?.full_address}
+              withArrow
+              color="rgba(0, 0, 0, 0.4)"
+              multiline
+              w={220}
+              position="bottom"
+            >
+              <Badge
+                variant="light"
+                title=""
+                style={{
+                  maxWidth: '220px',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  display: 'inline-block',
+                }}
+              >
+                {community?.full_address}
+              </Badge>
+            </Tooltip>
 
-          <LogoutButton />
+            <LogoutButton />
+          </Group>
         </Group>
       </Container>
     </Paper>

--- a/components/NavBar/UserNavbarWrapper.tsx
+++ b/components/NavBar/UserNavbarWrapper.tsx
@@ -1,0 +1,12 @@
+import { getCommunityInfo } from './getCommunityInfo';
+import { UserNavbar } from './UserNavbar';
+
+export default async function UserNavbarWrapper() {
+  const community = await getCommunityInfo();
+
+  return (
+    <>
+      <UserNavbar community={community} />
+    </>
+  );
+}

--- a/components/NavBar/getCommunityInfo.ts
+++ b/components/NavBar/getCommunityInfo.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+export async function getCommunityInfo() {
+  const supabase = await createClient();
+
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth?.user) return null;
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('community_id')
+    .eq('id', auth.user.id)
+    .single();
+
+  if (!profile?.community_id) return null;
+
+  const { data: community } = await supabase
+    .from('communities')
+    .select('id, full_address')
+    .eq('id', profile.community_id)
+    .single();
+
+  return community ?? null;
+}


### PR DESCRIPTION
Closes #141

- Added community address fetching via wrappers and updates both roles navbars to show it with a badge and tooltip.
Wrappers were added so navbars can stay client components while receiving server-fetched community data.

**Admin**
<img width="800" height="752" alt="Screenshot 2025-12-05 at 17 29 35" src="https://github.com/user-attachments/assets/8c01f542-8b25-46e3-8302-1ba973ff5e73" />
**User**
<img width="800" height="752" alt="Screenshot 2025-12-05 at 17 30 11" src="https://github.com/user-attachments/assets/d2dfbb99-e2ba-4091-9eb0-82cf04004650" />
