### PR TITLE
feat(navbars): add unit testing in navbars for both roles

### DIFF
--- a/components/NavBar/tests/AdminNavbar.test.tsx
+++ b/components/NavBar/tests/AdminNavbar.test.tsx
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AdminNavbar } from '../AdminNavbar';
+
+const mockPush = vi.fn();
+const mockPathname = '/protected/Admin/Notices';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('@mantine/core', async () => {
+  const actual = await vi.importActual('@mantine/core');
+  return {
+    ...actual,
+    Button: ({ children, onClick, variant, size, color, ...props }: any) => (
+      <button onClick={onClick} data-variant={variant} data-size={size} data-color={color}>
+        {children}
+      </button>
+    ),
+    Group: ({ children, gap, justify, align, wrap, ...props }: any) => (
+      <div data-gap={gap} data-justify={justify} data-align={align}>{children}</div>
+    ),
+    Container: ({ children, size, h, px, ...props }: any) => (
+      <div data-size={size} data-h={h} data-px={px}>{children}</div>
+    ),
+    Paper: ({ children, component, radius, withBorder, ...props }: any) => (
+      <div 
+        role={component === 'nav' ? 'navigation' : undefined}
+        data-radius={radius}
+        data-with-border={withBorder}
+      >
+        {children}
+      </div>
+    ),
+    Tooltip: ({ children, label, withArrow, color, multiline, w, position }: any) => (
+      <div title={label} data-with-arrow={withArrow} data-color={color}>
+        {children}
+      </div>
+    ),
+    Badge: ({ children, variant, title, style, ...props }: any) => (
+      <span style={style} data-variant={variant} title={title}>
+        {children}
+      </span>
+    ),
+  };
+});
+
+vi.mock('../logout-button', () => ({
+  LogoutButton: () => <button>Logout</button>,
+}));
+
+describe('AdminNavbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all navigation links', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.getByText('Worries')).toBeInTheDocument();
+    expect(screen.getByText('Residents')).toBeInTheDocument();
+    expect(screen.getByText('Create Meetings')).toBeInTheDocument();
+    expect(screen.getByText('Create Notice')).toBeInTheDocument();
+  });
+
+  it('renders community address when provided', () => {
+    const community = { id: '1', full_address: '123 Main St, City' };
+    render(<AdminNavbar community={community} />);
+
+    expect(screen.getByText('123 Main St, City')).toBeInTheDocument();
+  });
+
+  it('handles null community gracefully', () => {
+    render(<AdminNavbar community={null} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.queryByText('123 Main St')).not.toBeInTheDocument();
+  });
+
+  it('navigates to correct route when link is clicked', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const worriesButton = screen.getByText('Worries');
+    fireEvent.click(worriesButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/protected/Admin/Worries');
+  });
+
+  it('navigates to all routes correctly', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const routes = [
+      { button: 'Notices', path: '/protected/Admin/Notices' },
+      { button: 'Worries', path: '/protected/Admin/Worries' },
+      { button: 'Residents', path: '/protected/Admin/Residents' },
+      { button: 'Create Meetings', path: '/protected/Admin/Create-Meetings' },
+      { button: 'Create Notice', path: '/protected/Admin/CreateNotice' },
+    ];
+
+    routes.forEach(({ button, path }) => {
+      fireEvent.click(screen.getByText(button));
+      expect(mockPush).toHaveBeenCalledWith(path);
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(5);
+  });
+
+  it('highlights active link based on pathname', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const noticesButton = screen.getByText('Notices');
+    expect(noticesButton).toHaveAttribute('data-variant', 'light');
+
+    const worriesButton = screen.getByText('Worries');
+    expect(worriesButton).toHaveAttribute('data-variant', 'subtle');
+  });
+
+  it('only highlights the current page link', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const allButtons = [
+      screen.getByText('Notices'),
+      screen.getByText('Worries'),
+      screen.getByText('Residents'),
+      screen.getByText('Create Meetings'),
+      screen.getByText('Create Notice'),
+    ];
+
+    const activeButtons = allButtons.filter(btn => 
+      btn.getAttribute('data-variant') === 'light'
+    );
+    
+    expect(activeButtons).toHaveLength(1);
+    expect(activeButtons[0]).toHaveTextContent('Notices');
+  });
+
+  it('renders logout button', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('renders navigation with nav role', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('renders community badge with tooltip', () => {
+    const community = { id: '1', full_address: '123 Main St, City, State' };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const tooltip = container.querySelector('[title="123 Main St, City, State"]');
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('truncates long community addresses', () => {
+    const community = {
+      id: '1',
+      full_address: 'Very Long Address That Should Be Truncated, Building 5, Floor 3, City, State, ZIP',
+    };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="overflow"]');
+    expect(badge).toBeInTheDocument();
+    expect(badge?.textContent).toContain('Very Long Address');
+  });
+
+  it('renders with proper spacing structure', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const navigation = screen.getByRole('navigation');
+    expect(navigation).toBeInTheDocument();
+    
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    
+    expect(screen.getByText('123 Main St')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('renders empty community badge when community is null', () => {
+    render(<AdminNavbar community={null} />);
+
+    expect(screen.queryByText('123 Main St')).not.toBeInTheDocument();
+  });
+
+  it('renders all links as buttons', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const buttons = container.querySelectorAll('button');
+    // 5 navigation buttons + 1 logout button = 6 total
+    expect(buttons.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('handles click events without errors', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    expect(() => {
+      fireEvent.click(screen.getByText('Notices'));
+      fireEvent.click(screen.getByText('Worries'));
+      fireEvent.click(screen.getByText('Residents'));
+    }).not.toThrow();
+  });
+
+  it('maintains navigation state across renders', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { rerender } = render(<AdminNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toHaveAttribute('data-variant', 'light');
+
+    rerender(<AdminNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toHaveAttribute('data-variant', 'light');
+  });
+
+  it('handles community with only id', () => {
+    const community = { id: '1', full_address: '' };
+    render(<AdminNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('updates community address when community prop changes', () => {
+    const community1 = { id: '1', full_address: 'Address 1' };
+    const { rerender } = render(<AdminNavbar community={community1} />);
+
+    expect(screen.getByText('Address 1')).toBeInTheDocument();
+
+    const community2 = { id: '2', full_address: 'Address 2' };
+    rerender(<AdminNavbar community={community2} />);
+
+    expect(screen.queryByText('Address 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Address 2')).toBeInTheDocument();
+  });
+
+  it('handles special characters in community address', () => {
+    const community = { 
+      id: '1', 
+      full_address: 'Str. №5, Apt. 3/4, "Building A" & Co.' 
+    };
+    render(<AdminNavbar community={community} />);
+
+    expect(screen.getByText(/Str. №5, Apt. 3\/4/)).toBeInTheDocument();
+  });
+
+  it('all navigation links have unique labels', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const labels = ['Notices', 'Worries', 'Residents', 'Create Meetings', 'Create Notice'];
+    const uniqueLabels = new Set(labels);
+
+    expect(uniqueLabels.size).toBe(labels.length);
+  });
+
+  it('navigation maintains correct order', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const navButtons = buttons.slice(0, 5); // 5 are first navigation buttons
+
+    const expectedOrder = ['Notices', 'Worries', 'Residents', 'Create Meetings', 'Create Notice'];
+    const actualOrder = navButtons.map(btn => btn.textContent);
+
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('tooltip shows full address even when truncated', () => {
+    const longAddress = 'A'.repeat(250);
+    const community = { id: '1', full_address: longAddress };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const tooltip = container.querySelector(`[title="${longAddress}"]`);
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('badge has correct max-width styling', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="max-width: 220px"]');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('renders consistently with empty string address', () => {
+    const community = { id: '1', full_address: '' };
+    render(<AdminNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('does not break with undefined community properties', () => {
+    const community = { id: '1', full_address: undefined as any };
+    
+    expect(() => {
+      render(<AdminNavbar community={community} />);
+    }).not.toThrow();
+  });
+
+  it('navigation buttons are keyboard accessible', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const buttons = container.querySelectorAll('button');
+    buttons.forEach(button => {
+      expect(button.tagName).toBe('BUTTON');
+    });
+  });
+
+  it('calls router.push exactly once per navigation click', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const worriesButton = screen.getByText('Worries');
+    
+    mockPush.mockClear();
+    fireEvent.click(worriesButton);
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles rapid successive clicks', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<AdminNavbar community={community} />);
+
+    const noticesButton = screen.getByText('Notices');
+    
+    mockPush.mockClear();
+    fireEvent.click(noticesButton);
+    fireEvent.click(noticesButton);
+    fireEvent.click(noticesButton);
+
+    expect(mockPush).toHaveBeenCalledTimes(3);
+    expect(mockPush).toHaveBeenCalledWith('/protected/Admin/Notices');
+  });
+
+  it('community badge uses ellipsis for overflow', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="text-overflow: ellipsis"]');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('badge prevents text wrapping', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<AdminNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="white-space: nowrap"]');
+    expect(badge).toBeInTheDocument();
+  });
+});

--- a/components/NavBar/tests/AdminNavbarWrapper.test.tsx
+++ b/components/NavBar/tests/AdminNavbarWrapper.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AdminNavbarWrapper from '../AdminNavbarWrapper';
+import * as getCommunityInfoModule from '../getCommunityInfo';
+
+vi.mock('../getCommunityInfo', () => ({
+  getCommunityInfo: vi.fn(),
+}));
+
+vi.mock('../AdminNavbar', () => ({
+  AdminNavbar: ({ community }: any) => (
+    <div data-testid="admin-navbar">
+      {community ? (
+        <>
+          <span data-testid="community-id">{community.id}</span>
+          <span data-testid="community-address">{community.full_address}</span>
+        </>
+      ) : (
+        <span data-testid="no-community">No community</span>
+      )}
+    </div>
+  ),
+}));
+
+describe('AdminNavbarWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders AdminNavbar with community data', async () => {
+    const mockCommunity = {
+      id: 'comm-123',
+      full_address: '456 Oak Avenue',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="admin-navbar"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="community-id"]')).toHaveTextContent('comm-123');
+    expect(container.querySelector('[data-testid="community-address"]')).toHaveTextContent('456 Oak Avenue');
+  });
+
+  it('renders AdminNavbar with null community when no data is returned', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="admin-navbar"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="no-community"]')).toBeInTheDocument();
+  });
+
+  it('calls getCommunityInfo during render', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    await AdminNavbarWrapper();
+
+    expect(getCommunityInfoModule.getCommunityInfo).toHaveBeenCalledTimes(1);
+    expect(getCommunityInfoModule.getCommunityInfo).toHaveBeenCalledWith();
+  });
+
+  it('passes complete community data to AdminNavbar', async () => {
+    const mockCommunity = {
+      id: 'test-community-id',
+      full_address: 'Test Address 123, Building A',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="community-id"]')).toHaveTextContent('test-community-id');
+    expect(container.querySelector('[data-testid="community-address"]')).toHaveTextContent('Test Address 123, Building A');
+  });
+
+  it('handles getCommunityInfo returning undefined', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(undefined as any);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="admin-navbar"]')).toBeInTheDocument();
+  });
+
+  it('renders without errors when getCommunityInfo resolves', async () => {
+    const mockCommunity = {
+      id: '1',
+      full_address: 'Address',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    await expect(AdminNavbarWrapper()).resolves.toBeDefined();
+  });
+
+  it('handles different community addresses correctly', async () => {
+    const addresses = [
+      '123 Main Street',
+      'Apartment 5B, Building C',
+      'Very Long Address With Many Details, Street 123, Building 4, Floor 5',
+      '',
+    ];
+
+    for (const address of addresses) {
+      vi.clearAllMocks();
+      const mockCommunity = {
+        id: `id-${address.length}`,
+        full_address: address,
+      };
+
+      vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+      const component = await AdminNavbarWrapper();
+      const { container } = render(component);
+
+      const addressElement = container.querySelector('[data-testid="community-address"]');
+      if (address) {
+        expect(addressElement).toHaveTextContent(address);
+      }
+    }
+  });
+
+  it('renders AdminNavbar exactly once', async () => {
+    const mockCommunity = {
+      id: '1',
+      full_address: 'Test Address',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    const navbars = container.querySelectorAll('[data-testid="admin-navbar"]');
+    expect(navbars).toHaveLength(1);
+  });
+
+  it('returns valid React component', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const component = await AdminNavbarWrapper();
+    
+    expect(component).toBeDefined();
+    expect(typeof component).toBe('object');
+  });
+
+  it('handles special characters in community address', async () => {
+    const mockCommunity = {
+      id: 'special-123',
+      full_address: 'Str. №5, Apt. 3/4, "Building A" & Co.',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="community-address"]')).toHaveTextContent('Str. №5, Apt. 3/4, "Building A" & Co.');
+  });
+
+  it('preserves community id type', async () => {
+    const mockCommunity = {
+      id: '12345-uuid-format',
+      full_address: 'Test',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="community-id"]')).toHaveTextContent('12345-uuid-format');
+  });
+
+  it('wrapper is an async server component', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const result = AdminNavbarWrapper();
+    
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('handles getCommunityInfo rejection gracefully', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockRejectedValue(new Error('Database error'));
+
+    await expect(AdminNavbarWrapper()).rejects.toThrow('Database error');
+  });
+
+  it('renders fragment wrapper correctly', async () => {
+    const mockCommunity = {
+      id: '1',
+      full_address: 'Test',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="admin-navbar"]')).toBeInTheDocument();
+  });
+
+  it('passes null correctly when getCommunityInfo returns null', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const component = await AdminNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="no-community"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="community-id"]')).not.toBeInTheDocument();
+  });
+});

--- a/components/NavBar/tests/UserNavbar.test.tsx
+++ b/components/NavBar/tests/UserNavbar.test.tsx
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UserNavbar } from '../UserNavbar';
+
+const mockPush = vi.fn();
+const mockPathname = '/protected/Resident/Notices';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('@mantine/core', async () => {
+  const actual = await vi.importActual('@mantine/core');
+  return {
+    ...actual,
+    Group: ({ children, gap, justify, align, wrap, ...props }: any) => (
+      <div data-gap={gap} data-justify={justify} data-align={align}>{children}</div>
+    ),
+    Container: ({ children, size, h, px, ...props }: any) => (
+      <div data-size={size} data-h={h} data-px={px}>{children}</div>
+    ),
+    Paper: ({ children, component, radius, withBorder, ...props }: any) => (
+      <div 
+        role={component === 'nav' ? 'navigation' : undefined}
+        data-radius={radius}
+        data-with-border={withBorder}
+      >
+        {children}
+      </div>
+    ),
+    Tooltip: ({ children, label, withArrow, color, multiline, w, position }: any) => (
+      <div title={label} data-with-arrow={withArrow} data-color={color}>
+        {children}
+      </div>
+    ),
+    Badge: ({ children, variant, title, style, ...props }: any) => (
+      <span style={style} data-variant={variant} title={title}>
+        {children}
+      </span>
+    ),
+  };
+});
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, variant, size, ...props }: any) => (
+    <button onClick={onClick} data-variant={variant} data-size={size} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/logout-button', () => ({
+  LogoutButton: () => <button>Logout</button>,
+}));
+
+describe('UserNavbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all navigation links', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.getByText('Worries')).toBeInTheDocument();
+    expect(screen.getByText('Create Worry')).toBeInTheDocument();
+  });
+
+  it('renders community address when provided', () => {
+    const community = { id: '1', full_address: '456 Resident Ave' };
+    render(<UserNavbar community={community} />);
+
+    expect(screen.getByText('456 Resident Ave')).toBeInTheDocument();
+  });
+
+  it('handles null community gracefully', () => {
+    render(<UserNavbar community={null} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.queryByText('456 Resident Ave')).not.toBeInTheDocument();
+  });
+
+  it('navigates to correct route when link is clicked', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const worriesButton = screen.getByText('Worries');
+    fireEvent.click(worriesButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/protected/Resident/Worries');
+  });
+
+  it('navigates to all routes correctly', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const routes = [
+      { button: 'Notices', path: '/protected/Resident/Notices' },
+      { button: 'Worries', path: '/protected/Resident/Worries' },
+      { button: 'Create Worry', path: '/protected/Resident/Create-Worry' },
+    ];
+
+    routes.forEach(({ button, path }) => {
+      fireEvent.click(screen.getByText(button));
+      expect(mockPush).toHaveBeenCalledWith(path);
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(3);
+  });
+
+  it('highlights active link based on pathname', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const noticesButton = screen.getByText('Notices');
+    expect(noticesButton).toHaveAttribute('data-variant', 'secondary');
+
+    const worriesButton = screen.getByText('Worries');
+    expect(worriesButton).toHaveAttribute('data-variant', 'ghost');
+  });
+
+  it('only highlights the current page link', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const allButtons = [
+      screen.getByText('Notices'),
+      screen.getByText('Worries'),
+      screen.getByText('Create Worry'),
+    ];
+
+    const activeButtons = allButtons.filter(btn => 
+      btn.getAttribute('data-variant') === 'secondary'
+    );
+    
+    expect(activeButtons).toHaveLength(1);
+    expect(activeButtons[0]).toHaveTextContent('Notices');
+  });
+
+  it('renders logout button', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('renders navigation with nav role', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('renders community badge with tooltip', () => {
+    const community = { id: '1', full_address: '789 Test Street' };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const tooltip = container.querySelector('[title="789 Test Street"]');
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('truncates long community addresses', () => {
+    const community = {
+      id: '1',
+      full_address: 'Very Long Address That Should Be Truncated, Building 5, Floor 3, City, State, ZIP',
+    };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="overflow"]');
+    expect(badge).toBeInTheDocument();
+    expect(badge?.textContent).toContain('Very Long Address');
+  });
+
+  it('renders with proper spacing structure', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const navigation = screen.getByRole('navigation');
+    expect(navigation).toBeInTheDocument();
+    
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.getByText('123 Main St')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('renders empty community badge when community is null', () => {
+    render(<UserNavbar community={null} />);
+
+    expect(screen.queryByText('123 Main St')).not.toBeInTheDocument();
+  });
+
+  it('handles community with only id', () => {
+    const community = { id: '1', full_address: '' };
+    render(<UserNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('updates community address when community prop changes', () => {
+    const community1 = { id: '1', full_address: 'Address 1' };
+    const { rerender } = render(<UserNavbar community={community1} />);
+
+    expect(screen.getByText('Address 1')).toBeInTheDocument();
+
+    const community2 = { id: '2', full_address: 'Address 2' };
+    rerender(<UserNavbar community={community2} />);
+
+    expect(screen.queryByText('Address 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Address 2')).toBeInTheDocument();
+  });
+
+  it('handles special characters in community address', () => {
+    const community = { 
+      id: '1', 
+      full_address: 'Str. №5, Apt. 3/4, "Building A" & Co.' 
+    };
+    render(<UserNavbar community={community} />);
+
+    expect(screen.getByText(/Str. №5, Apt. 3\/4/)).toBeInTheDocument();
+  });
+
+  it('all navigation links have unique labels', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const labels = ['Notices', 'Worries', 'Create Worry'];
+    const uniqueLabels = new Set(labels);
+
+    expect(uniqueLabels.size).toBe(labels.length);
+  });
+
+  it('navigation maintains correct order', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const navButtons = buttons.slice(0, 3);
+
+    const expectedOrder = ['Notices', 'Worries', 'Create Worry'];
+    const actualOrder = navButtons.map(btn => btn.textContent);
+
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('tooltip shows full address even when truncated', () => {
+    const longAddress = 'A'.repeat(250);
+    const community = { id: '1', full_address: longAddress };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const tooltip = container.querySelector(`[title="${longAddress}"]`);
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('badge has correct max-width styling', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="max-width: 220px"]');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('renders consistently with empty string address', () => {
+    const community = { id: '1', full_address: '' };
+    render(<UserNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('does not break with undefined community properties', () => {
+    const community = { id: '1', full_address: undefined as any };
+    
+    expect(() => {
+      render(<UserNavbar community={community} />);
+    }).not.toThrow();
+  });
+
+  it('navigation buttons are keyboard accessible', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const buttons = container.querySelectorAll('button');
+    buttons.forEach(button => {
+      expect(button.tagName).toBe('BUTTON');
+    });
+  });
+
+  it('calls router.push exactly once per navigation click', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const worriesButton = screen.getByText('Worries');
+    
+    mockPush.mockClear();
+    fireEvent.click(worriesButton);
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles rapid successive clicks', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const noticesButton = screen.getByText('Notices');
+    
+    mockPush.mockClear();
+    fireEvent.click(noticesButton);
+    fireEvent.click(noticesButton);
+    fireEvent.click(noticesButton);
+
+    expect(mockPush).toHaveBeenCalledTimes(3);
+    expect(mockPush).toHaveBeenCalledWith('/protected/Resident/Notices');
+  });
+
+  it('community badge uses ellipsis for overflow', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="text-overflow: ellipsis"]');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('badge prevents text wrapping', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { container } = render(<UserNavbar community={community} />);
+
+    const badge = container.querySelector('span[style*="white-space: nowrap"]');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('uses shadcn/ui button component', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const noticesButton = screen.getByText('Notices');
+    expect(noticesButton).toHaveAttribute('data-size', 'sm');
+  });
+
+  it('active button uses secondary variant', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const noticesButton = screen.getByText('Notices');
+    expect(noticesButton).toHaveAttribute('data-variant', 'secondary');
+  });
+
+  it('inactive buttons use ghost variant', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    render(<UserNavbar community={community} />);
+
+    const worriesButton = screen.getByText('Worries');
+    const createWorryButton = screen.getByText('Create Worry');
+    
+    expect(worriesButton).toHaveAttribute('data-variant', 'ghost');
+    expect(createWorryButton).toHaveAttribute('data-variant', 'ghost');
+  });
+
+  it('maintains navigation state across renders', () => {
+    const community = { id: '1', full_address: '123 Main St' };
+    const { rerender } = render(<UserNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toHaveAttribute('data-variant', 'secondary');
+
+    rerender(<UserNavbar community={community} />);
+
+    expect(screen.getByText('Notices')).toHaveAttribute('data-variant', 'secondary');
+  });
+});

--- a/components/NavBar/tests/UserNavbarWrapper.test.tsx
+++ b/components/NavBar/tests/UserNavbarWrapper.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import UserNavbarWrapper from '../UserNavbarWrapper';
+import * as getCommunityInfoModule from '../getCommunityInfo';
+
+vi.mock('../getCommunityInfo', () => ({
+  getCommunityInfo: vi.fn(),
+}));
+
+vi.mock('../UserNavbar', () => ({
+  UserNavbar: ({ community }: any) => (
+    <div data-testid="user-navbar">
+      {community ? (
+        <>
+          <span data-testid="community-id">{community.id}</span>
+          <span data-testid="community-address">{community.full_address}</span>
+        </>
+      ) : (
+        <span data-testid="no-community">No community</span>
+      )}
+    </div>
+  ),
+}));
+
+describe('UserNavbarWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders UserNavbar with community data', async () => {
+    const mockCommunity = {
+      id: 'resident-comm-123',
+      full_address: '789 Resident Street',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="user-navbar"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="community-id"]')).toHaveTextContent('resident-comm-123');
+    expect(container.querySelector('[data-testid="community-address"]')).toHaveTextContent('789 Resident Street');
+  });
+
+  it('renders UserNavbar with null community when no data is returned', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="user-navbar"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="no-community"]')).toBeInTheDocument();
+  });
+
+  it('calls getCommunityInfo during render', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    await UserNavbarWrapper();
+
+    expect(getCommunityInfoModule.getCommunityInfo).toHaveBeenCalledTimes(1);
+    expect(getCommunityInfoModule.getCommunityInfo).toHaveBeenCalledWith();
+  });
+
+  it('passes complete community data to UserNavbar', async () => {
+    const mockCommunity = {
+      id: 'test-resident-id',
+      full_address: 'Test Resident Address 456, Unit B',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="community-id"]')).toHaveTextContent('test-resident-id');
+    expect(container.querySelector('[data-testid="community-address"]')).toHaveTextContent('Test Resident Address 456, Unit B');
+  });
+
+  it('handles getCommunityInfo returning undefined', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(undefined as any);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="user-navbar"]')).toBeInTheDocument();
+  });
+
+  it('renders without errors when getCommunityInfo resolves', async () => {
+    const mockCommunity = {
+      id: '1',
+      full_address: 'Address',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    await expect(UserNavbarWrapper()).resolves.toBeDefined();
+  });
+
+  it('handles different community addresses correctly', async () => {
+    const addresses = [
+      '123 Main Street',
+      'Apartment 5B, Building C',
+      'Very Long Address With Many Details, Street 123, Building 4, Floor 5',
+      '',
+    ];
+
+    for (const address of addresses) {
+      vi.clearAllMocks();
+      const mockCommunity = {
+        id: `id-${address.length}`,
+        full_address: address,
+      };
+
+      vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+      const component = await UserNavbarWrapper();
+      const { container } = render(component);
+
+      const addressElement = container.querySelector('[data-testid="community-address"]');
+      if (address) {
+        expect(addressElement).toHaveTextContent(address);
+      }
+    }
+  });
+
+  it('renders UserNavbar exactly once', async () => {
+    const mockCommunity = {
+      id: '1',
+      full_address: 'Test Address',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    const navbars = container.querySelectorAll('[data-testid="user-navbar"]');
+    expect(navbars).toHaveLength(1);
+  });
+
+  it('returns valid React component', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const component = await UserNavbarWrapper();
+    
+    expect(component).toBeDefined();
+    expect(typeof component).toBe('object');
+  });
+
+  it('handles special characters in community address', async () => {
+    const mockCommunity = {
+      id: 'special-resident-123',
+      full_address: 'Str. №5, Apt. 3/4, "Building A" & Co.',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="community-address"]')).toHaveTextContent('Str. №5, Apt. 3/4, "Building A" & Co.');
+  });
+
+  it('preserves community id type', async () => {
+    const mockCommunity = {
+      id: '67890-uuid-format',
+      full_address: 'Test',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="community-id"]')).toHaveTextContent('67890-uuid-format');
+  });
+
+  it('wrapper is an async server component', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const result = UserNavbarWrapper();
+    
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('handles getCommunityInfo rejection gracefully', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockRejectedValue(new Error('Database error'));
+
+    await expect(UserNavbarWrapper()).rejects.toThrow('Database error');
+  });
+
+  it('renders fragment wrapper correctly', async () => {
+    const mockCommunity = {
+      id: '1',
+      full_address: 'Test',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="user-navbar"]')).toBeInTheDocument();
+  });
+
+  it('passes null correctly when getCommunityInfo returns null', async () => {
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(null);
+
+    const component = await UserNavbarWrapper();
+    const { container } = render(component);
+
+    expect(container.querySelector('[data-testid="no-community"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="community-id"]')).not.toBeInTheDocument();
+  });
+
+  it('uses same getCommunityInfo as AdminNavbarWrapper', async () => {
+    const mockCommunity = {
+      id: 'shared-comm',
+      full_address: 'Shared Address',
+    };
+
+    vi.mocked(getCommunityInfoModule.getCommunityInfo).mockResolvedValue(mockCommunity);
+
+    await UserNavbarWrapper();
+
+    expect(getCommunityInfoModule.getCommunityInfo).toHaveBeenCalled();
+  });
+});

--- a/components/NavBar/tests/getCommunityInfo.test.tsx
+++ b/components/NavBar/tests/getCommunityInfo.test.tsx
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCommunityInfo } from '../getCommunityInfo';
+import * as supabaseServer from '@/lib/supabase/server';
+
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+const mockFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+describe('getCommunityInfo', () => {
+  let mockSupabaseClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSupabaseClient = {
+      auth: {
+        getUser: mockGetUser,
+      },
+      from: mockFrom,
+    };
+
+    mockFrom.mockReturnValue({
+      select: mockSelect,
+    });
+
+    mockSelect.mockReturnValue({
+      eq: mockEq,
+    });
+
+    mockEq.mockReturnValue({
+      single: mockSingle,
+    });
+
+    vi.mocked(supabaseServer.createClient).mockResolvedValue(mockSupabaseClient);
+  });
+
+  it('returns community info when user is authenticated and has a community', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { id: 'comm-456', full_address: '789 Pine Street' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toEqual(mockCommunity);
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(mockFrom).toHaveBeenCalledWith('communities');
+  });
+
+  it('returns null when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns null when auth data is missing', async () => {
+    mockGetUser.mockResolvedValue({ data: null, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns null when user has no community_id', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: null };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(mockFrom).not.toHaveBeenCalledWith('communities');
+  });
+
+  it('returns null when community is not found', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+  });
+
+  it('queries users table with correct user id', async () => {
+    const mockUser = { id: 'specific-user-id' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { id: 'comm-456', full_address: '123 Test St' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    expect(mockSelect).toHaveBeenCalledWith('community_id');
+    expect(mockEq).toHaveBeenCalledWith('id', 'specific-user-id');
+  });
+
+  it('queries communities table with correct community id', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'specific-comm-id' };
+    const mockCommunity = { id: 'specific-comm-id', full_address: '456 Test Ave' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'communities');
+    expect(mockSelect).toHaveBeenCalledWith('id, full_address');
+    expect(mockEq).toHaveBeenNthCalledWith(2, 'id', 'specific-comm-id');
+  });
+
+  it('handles database error when fetching user profile', async () => {
+    const mockUser = { id: 'user-123' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ 
+      data: null, 
+      error: { message: 'Database error' } 
+    });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+  });
+
+  it('handles database error when fetching community', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ 
+      data: null, 
+      error: { message: 'Community not found' } 
+    });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when user profile data is null', async () => {
+    const mockUser = { id: 'user-123' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+  });
+
+  it('creates Supabase client on each call', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { id: 'comm-456', full_address: 'Test' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    expect(supabaseServer.createClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows correct query flow', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { id: 'comm-456', full_address: 'Test' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    // Verify order of operations
+    expect(mockGetUser).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenNthCalledWith(1, 'users');
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'communities');
+  });
+
+  it('returns community with correct structure', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { 
+      id: 'comm-456', 
+      full_address: '123 Main St, City, State, ZIP' 
+    };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('full_address');
+    expect(result?.id).toBe('comm-456');
+    expect(result?.full_address).toBe('123 Main St, City, State, ZIP');
+  });
+
+  it('handles empty string community_id', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: '' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+  });
+
+  it('handles undefined community_id', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: undefined };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+  });
+
+  it('selects only required fields from users table', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456', other_field: 'ignored' };
+    const mockCommunity = { id: 'comm-456', full_address: 'Test' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    expect(mockSelect).toHaveBeenCalledWith('community_id');
+  });
+
+  it('selects only required fields from communities table', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { id: 'comm-456', full_address: 'Test' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    expect(mockSelect).toHaveBeenCalledWith('id, full_address');
+  });
+
+  it('uses single() to get one record from users', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { id: 'comm-456', full_address: 'Test' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    expect(mockSingle).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles auth error gracefully', async () => {
+    mockGetUser.mockResolvedValue({ 
+      data: null, 
+      error: { message: 'Auth error' } 
+    });
+
+    const result = await getCommunityInfo();
+
+    expect(result).toBeNull();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns null when profile has falsy community_id', async () => {
+    const mockUser = { id: 'user-123' };
+    const falsyCommunityIds = [null, undefined, '', 0, false];
+
+    for (const falsyId of falsyCommunityIds) {
+      vi.clearAllMocks();
+      vi.mocked(supabaseServer.createClient).mockResolvedValue(mockSupabaseClient);
+      
+      mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+      mockSingle.mockResolvedValueOnce({ 
+        data: { community_id: falsyId }, 
+        error: null 
+      });
+
+      const result = await getCommunityInfo();
+
+      expect(result).toBeNull();
+      expect(mockFrom).toHaveBeenCalledWith('users');
+      expect(mockFrom).not.toHaveBeenCalledWith('communities');
+    }
+  });
+
+  it('is a server-side function', async () => {
+    const mockUser = { id: 'user-123' };
+    const mockProfile = { community_id: 'comm-456' };
+    const mockCommunity = { id: 'comm-456', full_address: 'Test' };
+
+    mockGetUser.mockResolvedValue({ data: { user: mockUser }, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockProfile, error: null });
+    mockSingle.mockResolvedValueOnce({ data: mockCommunity, error: null });
+
+    await getCommunityInfo();
+
+    expect(supabaseServer.createClient).toHaveBeenCalled();
+  });
+});

--- a/components/tests/logout-button.test.tsx
+++ b/components/tests/logout-button.test.tsx
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LogoutButton } from '../logout-button';
+
+const mockReplace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}));
+
+const mockNotificationsShow = vi.fn();
+vi.mock('@mantine/notifications', () => ({
+  notifications: {
+    show: (...args: any[]) => mockNotificationsShow(...args),
+  },
+}));
+
+vi.mock('@mantine/core', () => ({
+  Button: ({ children, onClick, variant, color, size }: any) => (
+    <button 
+      onClick={onClick} 
+      data-variant={variant}
+      data-color={color}
+      data-size={size}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+describe('LogoutButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear all cookies before each test
+    document.cookie.split(';').forEach(cookie => {
+      const name = cookie.split('=')[0].trim();
+      document.cookie = `${name}=; Max-Age=0; path=/;`;
+    });
+  });
+
+  afterEach(() => {
+    document.cookie.split(';').forEach(cookie => {
+      const name = cookie.split('=')[0].trim();
+      document.cookie = `${name}=; Max-Age=0; path=/;`;
+    });
+  });
+
+  it('renders logout button with correct text', () => {
+    render(<LogoutButton />);
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('renders button as a button element', () => {
+    render(<LogoutButton />);
+    const button = screen.getByText('Logout');
+    expect(button.tagName).toBe('BUTTON');
+  });
+
+  it('renders button with filled variant', () => {
+    render(<LogoutButton />);
+    const button = screen.getByText('Logout');
+    expect(button).toHaveAttribute('data-variant', 'filled');
+  });
+
+  it('renders button with gray color', () => {
+    render(<LogoutButton />);
+    const button = screen.getByText('Logout');
+    expect(button).toHaveAttribute('data-color', 'gray');
+  });
+
+  it('renders button with xs size', () => {
+    render(<LogoutButton />);
+    const button = screen.getByText('Logout');
+    expect(button).toHaveAttribute('data-size', 'xs');
+  });
+
+  it('shows notification when clicked', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockNotificationsShow).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows notification with correct title', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockNotificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Logged out',
+      })
+    );
+  });
+
+  it('shows notification with correct message', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockNotificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'You have been successfully logged out.',
+      })
+    );
+  });
+
+  it('shows notification with gray color', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockNotificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'gray',
+      })
+    );
+  });
+
+  it('shows notification with all correct properties', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockNotificationsShow).toHaveBeenCalledWith({
+      title: 'Logged out',
+      message: 'You have been successfully logged out.',
+      color: 'gray',
+    });
+  });
+
+  it('redirects to login page when clicked', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('uses router.replace instead of router.push', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockReplace).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('clears sid cookie when clicked', () => {
+    document.cookie = 'sid=test-session-value; path=/';
+    
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    // Check cookie was cleared
+    const cookies = document.cookie;
+    expect(cookies).not.toContain('sid=test-session-value');
+  });
+
+  it('sets cookie with Max-Age=0 to clear it', () => {
+    const cookieSetter = vi.spyOn(document, 'cookie', 'set');
+    
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(cookieSetter).toHaveBeenCalledWith('sid=; Max-Age=0; path=/;');
+  });
+
+  it('sets cookie with correct path', () => {
+    const cookieSetter = vi.spyOn(document, 'cookie', 'set');
+    
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    const cookieValue = cookieSetter.mock.calls[0][0];
+    expect(cookieValue).toContain('path=/');
+  });
+
+  it('performs logout actions in correct order', () => {
+    const callOrder: string[] = [];
+
+    const cookieSetter = vi.spyOn(document, 'cookie', 'set');
+    cookieSetter.mockImplementation((value) => {
+      if (value.includes('Max-Age=0')) {
+        callOrder.push('cookie-cleared');
+      }
+      return true;
+    });
+
+    mockNotificationsShow.mockImplementation(() => {
+      callOrder.push('notification-shown');
+    });
+
+    mockReplace.mockImplementation(() => {
+      callOrder.push('redirected');
+    });
+
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(callOrder).toEqual([
+      'cookie-cleared',
+      'notification-shown',
+      'redirected',
+    ]);
+  });
+
+  it('handles multiple clicks correctly', () => {
+    render(<LogoutButton />);
+    const button = screen.getByText('Logout');
+    
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockNotificationsShow).toHaveBeenCalledTimes(3);
+    expect(mockReplace).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles click without errors', () => {
+    render(<LogoutButton />);
+    
+    expect(() => {
+      fireEvent.click(screen.getByText('Logout'));
+    }).not.toThrow();
+  });
+
+  it('calls all logout actions on single click', () => {
+    const cookieSetter = vi.spyOn(document, 'cookie', 'set');
+    
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(cookieSetter).toHaveBeenCalled();
+    expect(mockNotificationsShow).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalled();
+  });
+
+  it('notification call comes after cookie clearing', () => {
+    let cookieCleared = false;
+
+    const cookieSetter = vi.spyOn(document, 'cookie', 'set');
+    cookieSetter.mockImplementation(() => {
+      cookieCleared = true;
+      return true;
+    });
+
+    mockNotificationsShow.mockImplementation(() => {
+      expect(cookieCleared).toBe(true);
+    });
+
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+  });
+
+  it('redirect comes after notification', () => {
+    let notificationShown = false;
+
+    mockNotificationsShow.mockImplementation(() => {
+      notificationShown = true;
+    });
+
+    mockReplace.mockImplementation(() => {
+      expect(notificationShown).toBe(true);
+    });
+
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+  });
+
+  it('does not redirect to other pages', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockReplace).not.toHaveBeenCalledWith('/dashboard');
+    expect(mockReplace).not.toHaveBeenCalledWith('/home');
+    expect(mockReplace).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('uses Mantine Button component', () => {
+    render(<LogoutButton />);
+    const button = screen.getByText('Logout');
+    
+    expect(button).toHaveAttribute('data-variant');
+    expect(button).toHaveAttribute('data-color');
+    expect(button).toHaveAttribute('data-size');
+  });
+
+  it('button has onClick handler', () => {
+    render(<LogoutButton />);
+    const button = screen.getByText('Logout');
+    
+    expect(button).toHaveProperty('onclick');
+  });
+
+  it('clears only sid cookie, not all cookies', () => {
+    document.cookie = 'sid=session123; path=/';
+    document.cookie = 'other=value; path=/';
+    
+    const cookieSetter = vi.spyOn(document, 'cookie', 'set');
+    
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(cookieSetter).toHaveBeenCalledWith('sid=; Max-Age=0; path=/;');
+    expect(cookieSetter).not.toHaveBeenCalledWith('other=; Max-Age=0; path=/;');
+  });
+
+  it('handleLogout is called on button click', () => {
+    render(<LogoutButton />);
+    
+    mockReplace.mockClear();
+    mockNotificationsShow.mockClear();
+    
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(mockReplace).toHaveBeenCalled();
+    expect(mockNotificationsShow).toHaveBeenCalled();
+  });
+
+  it('renders as a client component', () => {
+    expect(() => {
+      render(<LogoutButton />);
+    }).not.toThrow();
+  });
+
+  it('notification has exactly three properties', () => {
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByText('Logout'));
+
+    const callArgs = mockNotificationsShow.mock.calls[0][0];
+    const keys = Object.keys(callArgs);
+    
+    expect(keys).toHaveLength(3);
+    expect(keys).toContain('title');
+    expect(keys).toContain('message');
+    expect(keys).toContain('color');
+  });
+
+  it('preserves button functionality after multiple renders', () => {
+    const { rerender } = render(<LogoutButton />);
+    
+    fireEvent.click(screen.getByText('Logout'));
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    
+    mockReplace.mockClear();
+    rerender(<LogoutButton />);
+    
+    fireEvent.click(screen.getByText('Logout'));
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #151

- Added unit testing for AdminNavbar and UserNavbar, their wrappers, getCommunityInfo, and the logout button.