### PR TITLE
feat(create-notice): add unit tests for create notice page

### DIFF
--- a/app/protected/Admin/Create-Meetings/tests/actions.test.tsx
+++ b/app/protected/Admin/Create-Meetings/tests/actions.test.tsx
@@ -42,7 +42,7 @@ beforeEach(() => {
   });
 });
 
-describe('createMeeting', () => {
+describe('actions Create-Meeting', () => {
   describe('Valid Meeting Creation', () => {
     it('successfully creates a meeting with all valid data', async () => {
       mockSupabaseFrom.mockReturnValue({

--- a/app/protected/Admin/CreateNotice/tests/CreateNoticeForm.test.tsx
+++ b/app/protected/Admin/CreateNotice/tests/CreateNoticeForm.test.tsx
@@ -1,0 +1,497 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CreateNoticeForm from '../components/CreateNoticeForm';
+import { createNotice } from '../actions';
+import { notifications } from '@mantine/notifications';
+
+vi.mock('../actions', () => ({
+  createNotice: vi.fn()
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: {
+    show: vi.fn()
+  }
+}));
+
+vi.mock('@mantine/core', async () => {
+  const actual = await vi.importActual('@mantine/core');
+  return {
+    ...actual,
+    TextInput: ({ label, name, value, onChange, ...props }: any) => (
+      <input
+        aria-label={label}
+        name={name}
+        value={value}
+        onChange={onChange}
+        data-testid={`textinput-${name}`}
+        {...props}
+      />
+    ),
+    Textarea: ({ label, name, value, onChange, ...props }: any) => (
+      <textarea
+        aria-label={label}
+        name={name}
+        value={value}
+        onChange={onChange}
+        data-testid={`textarea-${name}`}
+        {...props}
+      />
+    ),
+    Button: ({ children, type, ...props }: any) => (
+      <button type={type} {...props}>{children}</button>
+    ),
+    Card: ({ children, ...props }: any) => (
+      <div data-testid="card" {...props}>{children}</div>
+    ),
+    Title: ({ children }: any) => <h2>{children}</h2>,
+    Stack: ({ children }: any) => <div data-testid="stack">{children}</div>,
+    Text: ({ children, c }: any) => (
+      <span data-testid={c ? `text-${c}` : 'text'}>{children}</span>
+    ),
+    Select: ({ label, name, value, onChange, data }: any) => (
+      <select
+        aria-label={label}
+        name={name}
+        value={value || ''}
+        onChange={(e) => onChange(e.target.value)}
+        data-testid={`select-${name}`}
+      >
+        {data?.map((item: string) => (
+          <option key={item} value={item}>{item}</option>
+        ))}
+      </select>
+    ),
+    LoadingOverlay: ({ visible }: any) => visible ? <div data-testid="loading-overlay">Loading...</div> : null,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CreateNoticeForm', () => {
+  describe('Form Rendering', () => {
+    it('renders the form with all fields', () => {
+      render(<CreateNoticeForm />);
+
+      expect(screen.getByLabelText('Title')).toBeTruthy();
+      expect(screen.getByLabelText('Notice Content')).toBeTruthy();
+      expect(screen.getByLabelText('Category')).toBeTruthy();
+    });
+
+    it('renders the form title "Create Notice"', () => {
+      render(<CreateNoticeForm />);
+      expect(screen.getByText('Create Notice')).toBeTruthy();
+    });
+
+    it('renders the submit button', () => {
+      render(<CreateNoticeForm />);
+      expect(screen.getByRole('button', { name: /create/i })).toBeTruthy();
+    });
+
+    it('renders Card component as form wrapper', () => {
+      render(<CreateNoticeForm />);
+      expect(screen.getByTestId('card')).toBeTruthy();
+    });
+  });
+
+  describe('Form Validation', () => {
+    it('prevents submission when title is empty', async () => {
+      render(<CreateNoticeForm />);
+
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      fireEvent.change(contentInput, { target: { value: 'Some content' } });
+
+      const submitButton = screen.getByRole('button', { name: /create/i });
+      fireEvent.click(submitButton);
+
+      expect(createNotice).not.toHaveBeenCalled();
+    });
+
+    it('prevents submission when content is empty', async () => {
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      fireEvent.change(titleInput, { target: { value: 'Test Title' } });
+
+      const submitButton = screen.getByRole('button', { name: /create/i });
+      fireEvent.click(submitButton);
+
+      expect(createNotice).not.toHaveBeenCalled();
+    });
+
+    it('prevents submission when both title and content are empty', async () => {
+      render(<CreateNoticeForm />);
+
+      const submitButton = screen.getByRole('button', { name: /create/i });
+      fireEvent.click(submitButton);
+
+      expect(createNotice).not.toHaveBeenCalled();
+    });
+
+    it('allows submission when both title and content are provided', async () => {
+      (createNotice as any).mockResolvedValueOnce({});
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Test Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Test Content' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(createNotice).toHaveBeenCalled();
+      });
+    });
+
+    it('trims whitespace from title validation', async () => {
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: '   ' } });
+      fireEvent.change(contentInput, { target: { value: 'Content' } });
+
+      const submitButton = screen.getByRole('button', { name: /create/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(createNotice).not.toHaveBeenCalled();
+      });
+
+      expect(screen.getByText('Title is required.')).toBeTruthy();
+    });
+
+    it('trims whitespace from content validation', async () => {
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Title' } });
+      fireEvent.change(contentInput, { target: { value: '   ' } });
+
+      const submitButton = screen.getByRole('button', { name: /create/i });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(createNotice).not.toHaveBeenCalled();
+      });
+
+      expect(screen.getByText('Content is required.')).toBeTruthy();
+    });
+  });
+
+  describe('Form Submission', () => {
+    it('calls createNotice with correct FormData on successful submission', async () => {
+      (createNotice as any).mockResolvedValueOnce({});
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      const categorySelect = screen.getByLabelText('Category') as HTMLSelectElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Notice Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Notice Content' } });
+      fireEvent.change(categorySelect, { target: { value: 'Maintenance' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(createNotice).toHaveBeenCalledOnce();
+      });
+    });
+
+    it('shows success notification on successful submission', async () => {
+      (createNotice as any).mockResolvedValueOnce({});
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Test Notice' } });
+      fireEvent.change(contentInput, { target: { value: 'Test Content' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(notifications.show).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Notice created',
+            message: 'The notice was successfully created!',
+            color: 'green',
+          })
+        );
+      });
+    });
+
+    it('resets form fields after successful submission', async () => {
+      (createNotice as any).mockResolvedValueOnce({});
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      const categorySelect = screen.getByLabelText('Category') as HTMLSelectElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Test Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Test Content' } });
+      fireEvent.change(categorySelect, { target: { value: 'Maintenance' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(titleInput.value).toBe('');
+        expect(contentInput.value).toBe('');
+        expect(categorySelect.value).toBe('General');
+      });
+    });
+  });
+
+  describe('Category Selection', () => {
+    it('renders category select with correct options', () => {
+      render(<CreateNoticeForm />);
+
+      const categorySelect = screen.getByLabelText('Category') as HTMLSelectElement;
+      const options = Array.from(categorySelect.options).map(opt => opt.value);
+
+      expect(options).toContain('General');
+      expect(options).toContain('Maintenance');
+      expect(options).toContain('Safety');
+    });
+
+    it('defaults to "General" category', () => {
+      render(<CreateNoticeForm />);
+
+      const categorySelect = screen.getByLabelText('Category') as HTMLSelectElement;
+      expect(categorySelect.value).toBe('General');
+    });
+
+    it('updates category when user selects different option', () => {
+      render(<CreateNoticeForm />);
+
+      const categorySelect = screen.getByLabelText('Category') as HTMLSelectElement;
+      fireEvent.change(categorySelect, { target: { value: 'Safety' } });
+
+      expect(categorySelect.value).toBe('Safety');
+    });
+
+    it('sends selected category in FormData on submission', async () => {
+      (createNotice as any).mockResolvedValueOnce({});
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      const categorySelect = screen.getByLabelText('Category') as HTMLSelectElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Test Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Test Content' } });
+      fireEvent.change(categorySelect, { target: { value: 'Maintenance' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(createNotice).toHaveBeenCalledOnce();
+        const formData = (createNotice as any).mock.calls[0][0] as FormData;
+        expect(formData.get('category')).toBe('Maintenance');
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error message when createNotice throws Error', async () => {
+      (createNotice as any).mockRejectedValueOnce(new Error('Server error'));
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Content' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('text-red')).toHaveTextContent('Server error');
+      });
+    });
+
+    it('displays "Unknown error" when createNotice throws non-Error', async () => {
+      (createNotice as any).mockRejectedValueOnce('Unknown');
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Content' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('text-red')).toHaveTextContent('Unknown error');
+      });
+    });
+
+    it('clears previous error when submitting again', async () => {
+      (createNotice as any).mockRejectedValueOnce(new Error('First error'));
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Content' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('text-red')).toHaveTextContent('First error');
+      });
+
+      (createNotice as any).mockResolvedValueOnce({});
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('text-red')).toBeNull();
+      });
+    });
+  });
+
+  describe('Loading State', () => {
+    it('shows loading overlay when form is submitting', async () => {
+      let resolveSubmit: () => void = () => {};
+      const submitPromise = new Promise<void>(resolve => {
+        resolveSubmit = resolve;
+      });
+
+      (createNotice as any).mockReturnValueOnce(submitPromise);
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Content' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-overlay')).toBeTruthy();
+      });
+
+      resolveSubmit();
+    });
+
+    it('hides loading overlay after submission completes', async () => {
+      let resolveSubmit: () => void = () => {};
+      const submitPromise = new Promise<void>(resolve => {
+        resolveSubmit = resolve;
+      });
+
+      (createNotice as any).mockReturnValueOnce(submitPromise);
+
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Title' } });
+      fireEvent.change(contentInput, { target: { value: 'Content' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-overlay')).toBeTruthy();
+      });
+
+      resolveSubmit();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('loading-overlay')).toBeNull();
+      });
+    });
+  });
+
+  describe('Input Handling', () => {
+    it('updates title input when user types', () => {
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      fireEvent.change(titleInput, { target: { value: 'New Title' } });
+
+      expect(titleInput.value).toBe('New Title');
+    });
+
+    it('updates content input when user types', () => {
+      render(<CreateNoticeForm />);
+
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      fireEvent.change(contentInput, { target: { value: 'New Content' } });
+
+      expect(contentInput.value).toBe('New Content');
+    });
+
+    it('allows multi-line content input', () => {
+      render(<CreateNoticeForm />);
+
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      const multilineContent = 'Line 1\nLine 2\nLine 3';
+      fireEvent.change(contentInput, { target: { value: multilineContent } });
+
+      expect(contentInput.value).toBe(multilineContent);
+    });
+  });
+
+  describe('Form Elements', () => {
+    it('title input is marked as required', () => {
+      render(<CreateNoticeForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      expect(titleInput).toHaveAttribute('required');
+    });
+
+    it('content textarea is marked as required', () => {
+      render(<CreateNoticeForm />);
+
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      expect(contentInput).toHaveAttribute('required');
+    });
+
+    it('content textarea has minimum rows set to 3', () => {
+      render(<CreateNoticeForm />);
+
+      const contentInput = screen.getByLabelText('Notice Content') as HTMLTextAreaElement;
+      expect(contentInput).toHaveAttribute('minrows', '3');
+    });
+  });
+
+  describe('Form Attributes', () => {
+    it('form prevents default submission', () => {
+      render(<CreateNoticeForm />);
+
+      const form = screen.getByRole('button', { name: /create/i }).closest('form');
+      expect(form).toBeTruthy();
+    });
+
+    it('submit button has correct type', () => {
+      render(<CreateNoticeForm />);
+
+      const submitButton = screen.getByRole('button', { name: /create/i }) as HTMLButtonElement;
+      expect(submitButton.type).toBe('submit');
+    });
+  });
+});

--- a/app/protected/Admin/CreateNotice/tests/actions.test.tsx
+++ b/app/protected/Admin/CreateNotice/tests/actions.test.tsx
@@ -1,0 +1,435 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createNotice } from '../actions';
+import { revalidatePath } from 'next/cache';
+
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+const mockInsert = vi.fn();
+const mockFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+const mockSupabase = {
+  auth: {
+    getUser: mockGetUser,
+  },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+function createFormData(values: Record<string, string | null>) {
+  const fd = new FormData();
+  for (const [key, val] of Object.entries(values)) {
+    if (val !== null) fd.append(key, val);
+  }
+  return fd;
+}
+
+function setupSelectChain() {
+  mockFrom.mockReturnValue({
+    select: mockSelect,
+  });
+
+  mockSelect.mockReturnValue({
+    eq: mockEq,
+  });
+
+  mockEq.mockReturnValue({
+    single: mockSingle,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelect.mockReset();
+  mockEq.mockReset();
+  mockSingle.mockReset();
+  mockInsert.mockReset();
+  mockFrom.mockReset();
+
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: 'test-user-id' } },
+  });
+
+  setupSelectChain();
+});
+
+describe('actions Create-Notice', () => {
+  describe('Validation', () => {
+    it('throws ERROR_INVALID_CONTENT when content is missing', async () => {
+      const fd = new FormData();
+      fd.append('title', 'Hello');
+      fd.append('category', 'General');
+
+      await expect(createNotice(fd)).rejects.toThrow('ERROR_INVALID_CONTENT');
+    });
+
+    it('throws ERROR_INVALID_TITLE when title is missing', async () => {
+      const fd = new FormData();
+      fd.append('content', 'Hello');
+      fd.append('category', 'General');
+
+      await expect(createNotice(fd)).rejects.toThrow('ERROR_INVALID_TITLE');
+    });
+
+    it('throws ERROR_INVALID_CATEGORY when category missing', async () => {
+      const formData = createFormData({
+        title: 'Test',
+        content: 'Content',
+        category: null,
+      });
+
+      mockSingle.mockResolvedValueOnce({
+        data: { role: 'admin', community_id: 'community-123' },
+        error: null,
+      });
+
+      await expect(createNotice(formData)).rejects.toThrow('ERROR_INVALID_CATEGORY');
+    });
+  });
+
+  describe('Sanitization', () => {
+    it('strips HTML tags from title, content, and category', async () => {
+      const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle.mockResolvedValue({
+          data: { role: 'admin', community_id: 'COMM1' },
+          error: null,
+        }),
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: insertMock,
+      });
+
+      const fd = createFormData({
+        title: '<b>Hello</b>',
+        content: '<script>bad()</script> world',
+        category: '<i>General</i>',
+      });
+
+      await createNotice(fd);
+
+      const inserted = insertMock.mock.calls[0][0];
+      expect(inserted.title).toBe('Hello');
+      expect(inserted.content).toBe('bad() world');
+      expect(inserted.category).toBe('General');
+    });
+
+    it('trims whitespace', async () => {
+      const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle.mockResolvedValue({
+          data: { role: 'admin', community_id: 'C1' },
+          error: null,
+        }),
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: insertMock,
+      });
+
+      const fd = createFormData({
+        title: '   Title   ',
+        content: '   Content   ',
+        category: '   Safety   ',
+      });
+
+      await createNotice(fd);
+
+      const payload = insertMock.mock.calls[0][0];
+      expect(payload.title).toBe('Title');
+      expect(payload.content).toBe('Content');
+      expect(payload.category).toBe('Safety');
+    });
+  });
+
+  describe('Auth & Role Checks', () => {
+    it('throws ERROR_UNAUTHORIZED when no user', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+
+      const fd = createFormData({
+        title: 'T',
+        content: 'C',
+        category: 'General',
+      });
+
+      await expect(createNotice(fd)).rejects.toThrow('ERROR_UNAUTHORIZED');
+    });
+
+    it('throws ERROR_FETCHING_PROFILE when profile fails', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: new Error('DB fail'),
+      });
+
+      const fd = createFormData({
+        title: 'T',
+        content: 'C',
+        category: 'General',
+      });
+
+      await expect(createNotice(fd)).rejects.toThrow('ERROR_FETCHING_PROFILE');
+    });
+
+    it('throws ERROR_FORBIDDEN when user is not admin', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: { role: 'user', community_id: 'C1' },
+        error: null,
+      });
+
+      const fd = createFormData({
+        title: 'T',
+        content: 'C',
+        category: 'General',
+      });
+
+      await expect(createNotice(fd)).rejects.toThrow('ERROR_FORBIDDEN');
+    });
+
+    it('throws ERROR_NO_COMMUNITY for falsy community ids', async () => {
+      const falsy = [null, '', undefined];
+
+      for (const val of falsy) {
+        mockSingle.mockResolvedValueOnce({
+          data: { role: 'admin', community_id: val },
+          error: null,
+        });
+
+        const fd = createFormData({
+          title: 'A',
+          content: 'B',
+          category: 'General',
+        });
+
+        await expect(createNotice(fd)).rejects.toThrow('ERROR_NO_COMMUNITY');
+
+        mockSingle.mockReset();
+      }
+    });
+  });
+
+  describe('Insert & DB Errors', () => {
+    it('throws ERROR_INSERT_FAILED when insert fails', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: { role: 'admin', community_id: 'C1' },
+        error: null,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: vi.fn().mockResolvedValue({ error: new Error('Insert fail') }),
+      });
+
+      const fd = createFormData({
+        title: 'T',
+        content: 'C',
+        category: 'General',
+      });
+
+      await expect(createNotice(fd)).rejects.toThrow('ERROR_INSERT_FAILED');
+    });
+
+    it('inserts correct structure', async () => {
+      const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+      mockSingle.mockResolvedValueOnce({
+        data: { role: 'admin', community_id: 'COMM-77' },
+        error: null,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: insertMock,
+      });
+
+      const fd = createFormData({
+        title: 'X',
+        content: 'Y',
+        category: 'General',
+      });
+
+      await createNotice(fd);
+
+      expect(insertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'X',
+          content: 'Y',
+          category: 'General',
+          created_by: 'test-user-id',
+          community_id: 'COMM-77',
+        })
+      );
+    });
+
+    it('inserts into notices table', async () => {
+      const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+      mockSingle.mockResolvedValueOnce({
+        data: { role: 'admin', community_id: 'C1' },
+        error: null,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: insertMock,
+      });
+
+      const fd = createFormData({
+        title: 'A',
+        content: 'B',
+        category: 'General',
+      });
+
+      await createNotice(fd);
+
+      expect(mockFrom).toHaveBeenNthCalledWith(2, 'notices');
+    });
+  });
+
+  describe('Query Semantics', () => {
+    it('queries users with correct fields', async () => {
+      mockSingle
+        .mockResolvedValueOnce({ data: { role: 'admin', community_id: 'C1' }, error: null })
+        .mockResolvedValueOnce({ error: null });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      });
+
+      const fd = createFormData({
+        title: 'X',
+        content: 'Y',
+        category: 'General',
+      });
+
+      await createNotice(fd);
+
+      expect(mockFrom).toHaveBeenCalledWith('users');
+      expect(mockSelect).toHaveBeenCalledWith('id, role, community_id');
+      expect(mockEq).toHaveBeenCalledWith('id', 'test-user-id');
+      expect(mockSingle).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('System Integration', () => {
+    it('revalidates correct path', async () => {
+      const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+      mockSingle
+        .mockResolvedValueOnce({ data: { role: 'admin', community_id: 'C1' }, error: null })
+        .mockResolvedValueOnce({ error: null });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: insertMock,
+      });
+
+      const fd = createFormData({
+        title: 'T',
+        content: 'C',
+        category: 'General',
+      });
+
+      await createNotice(fd);
+
+      expect(revalidatePath).toHaveBeenCalledWith('/protected/Admin/Notices');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('wraps non Error into ERROR_UNKNOWN', async () => {
+      mockGetUser.mockRejectedValueOnce('oops');
+
+      const fd = createFormData({
+        title: 'T',
+        content: 'C',
+        category: 'General',
+      });
+
+      await expect(createNotice(fd)).rejects.toThrow('ERROR_UNKNOWN');
+    });
+
+    it('preserves native Error instance', async () => {
+      mockGetUser.mockRejectedValueOnce(new Error('ERR_CUSTOM'));
+
+      const fd = createFormData({
+        title: 'T',
+        content: 'C',
+        category: 'General',
+      });
+
+      await expect(createNotice(fd)).rejects.toThrow('ERR_CUSTOM');
+    });
+  });
+
+ 
+  describe('Full Flow', () => {
+    it('creates notice from start to finish successfully', async () => {
+      const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+      mockSingle
+        .mockResolvedValueOnce({ data: { role: 'admin', community_id: 'C1' }, error: null })
+        .mockResolvedValueOnce({ error: null });
+
+      mockFrom.mockReturnValueOnce({
+        select: mockSelect,
+        eq: mockEq,
+        single: mockSingle,
+      });
+
+      mockFrom.mockReturnValueOnce({
+        insert: insertMock,
+      });
+
+      const fd = createFormData({
+        title: 'Announcement',
+        content: 'Meeting Tomorrow',
+        category: 'General',
+      });
+
+      await expect(createNotice(fd)).resolves.not.toThrow();
+      expect(insertMock).toHaveBeenCalledOnce();
+      expect(revalidatePath).toHaveBeenCalledWith('/protected/Admin/Notices');
+    });
+  });
+});

--- a/app/protected/Admin/CreateNotice/tests/page.test.tsx
+++ b/app/protected/Admin/CreateNotice/tests/page.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CreateNoticePage from '../page';
+
+vi.mock('@mantine/core', async () => {
+  const actual = await vi.importActual<any>('@mantine/core');
+  return {
+    ...actual,
+    Flex: ({ children, ...props }: any) => (
+      <div data-testid="mantine-flex" {...props}>
+        {children}
+      </div>
+    ),
+  };
+});
+
+vi.mock('../components/CreateNoticeForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="create-notice-form" />,
+}));
+
+describe('CreateNoticePage', () => {
+  it('renders without crashing', () => {
+    render(<CreateNoticePage />);
+    expect(screen.getByTestId('mantine-flex')).toBeTruthy();
+  });
+
+  it('renders the CreateNoticeForm component', () => {
+    render(<CreateNoticePage />);
+    expect(screen.getByTestId('create-notice-form')).toBeTruthy();
+  });
+
+  it('wraps CreateNoticeForm inside Flex', () => {
+    render(<CreateNoticePage />);
+
+    const flex = screen.getByTestId('mantine-flex');
+    const form = screen.getByTestId('create-notice-form');
+
+    expect(flex.contains(form)).toBe(true);
+  });
+
+  it('applies correct Flex layout props', () => {
+    render(<CreateNoticePage />);
+    const flex = screen.getByTestId('mantine-flex');
+
+    expect(flex.getAttribute('justify')).toBe('center');
+    expect(flex.style.paddingTop).toBe('3rem');
+  });
+});


### PR DESCRIPTION
Closes #147 

- Added unit testing for CreateNotice page, and all related files to it
- Changed name of actions files to have it equally everywhere