### PR TITLE
feat(create-worry): add unit tests for create worry page

### DIFF
--- a/app/protected/Resident/Create-Worry/tests/CreateWorryForm.test.tsx
+++ b/app/protected/Resident/Create-Worry/tests/CreateWorryForm.test.tsx
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CreateWorryForm from '../components/CreateWorryForm';
+import { createWorry } from '../actions';
+import { notifications } from '@mantine/notifications';
+
+vi.mock('../actions', () => ({
+  createWorry: vi.fn(),
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: {
+    show: vi.fn(),
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  FileText: () => null,
+}));
+
+vi.mock('@mantine/core', async () => {
+  const actual = await vi.importActual('@mantine/core');
+  return {
+    ...actual,
+    TextInput: ({ label, name, value, onChange }: any) => (
+      <input
+        aria-label={label}
+        name={name}
+        value={value}
+        onChange={onChange}
+        data-testid={`textinput-${name}`}
+      />
+    ),
+    Textarea: ({ label, name, value, onChange }: any) => (
+      <textarea
+        aria-label={label}
+        name={name}
+        value={value}
+        onChange={onChange}
+        data-testid={`textarea-${name}`}
+      />
+    ),
+    Button: ({ children, type, ...props }: any) => (
+      <button type={type} {...props}>
+        {children}
+      </button>
+    ),
+    Card: ({ children }: any) => <div data-testid="card">{children}</div>,
+    Title: ({ children }: any) => <h2>{children}</h2>,
+    Text: ({ children, c }: any) => <span data-testid={c ? `text-${c}` : 'text'}>{children}</span>,
+    Group: ({ children }: any) => <div data-testid="group">{children}</div>,
+    Stack: ({ children }: any) => <div data-testid="stack">{children}</div>,
+    LoadingOverlay: ({ visible }: any) =>
+      visible ? <div data-testid="loading-overlay">Loading...</div> : null,
+  };
+});
+
+vi.mock('react-dom', () => ({
+  ...vi.importActual('react-dom'),
+  createPortal: (el: any) => el,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CreateWorryForm', () => {
+  describe('Form Validation', () => {
+    it('prevents submission when title is empty', async () => {
+      render(<CreateWorryForm />);
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(createWorry).not.toHaveBeenCalled();
+      });
+
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Title is required.',
+        })
+      );
+    });
+
+    it('prevents submission when content is empty', async () => {
+      render(<CreateWorryForm />);
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Some title' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(createWorry).not.toHaveBeenCalled();
+      });
+
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Description is required.',
+        })
+      );
+    });
+
+    it('shows validation error when title exceeds 200 characters', async () => {
+      render(<CreateWorryForm />);
+
+      const longTitle = 'a'.repeat(201);
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: longTitle } });
+      fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Valid text' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(notifications.show).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'Title is too long.',
+          })
+        );
+      });
+
+      expect(createWorry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Form Submission', () => {
+    it('submits successfully when all fields are valid', async () => {
+      (createWorry as any).mockResolvedValueOnce({});
+
+      render(<CreateWorryForm />);
+
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'My worry' } });
+      fireEvent.change(screen.getByLabelText('Description'), {
+        target: { value: 'Something worries me' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(createWorry).toHaveBeenCalled();
+      });
+
+      expect(notifications.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Created Worry',
+          message: 'Worry created successfully!',
+          color: 'green',
+        })
+      );
+    });
+
+    it('resets form fields after successful submission', async () => {
+      (createWorry as any).mockResolvedValueOnce({});
+
+      render(<CreateWorryForm />);
+
+      const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+      const contentInput = screen.getByLabelText('Description') as HTMLTextAreaElement;
+
+      fireEvent.change(titleInput, { target: { value: 'Something' } });
+      fireEvent.change(contentInput, { target: { value: 'Content text' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(createWorry).toHaveBeenCalled();
+      });
+
+      expect(titleInput.value).toBe('');
+      expect(contentInput.value).toBe('');
+    });
+  });
+
+  describe('Error Handling', () => {
+    const serverErrorMap = {
+      ERROR_NO_TITLE: 'Title is required.',
+      ERROR_TITLE_TOO_LONG: 'Title is too long.',
+      ERROR_DESCRIPTION_TOO_LONG: 'Description is too long.',
+      ERROR_UNAUTHORIZED: 'You are not authorized.',
+      ERROR_USER_HAS_NO_COMMUNITY: 'You are not assigned to a community.',
+      ERROR_DB_INSERT_FAILED: 'Failed to save the notice.',
+      ERROR_FETCHING_PROFILE: 'Cannot load profile.',
+      ERROR_UNKNOWN: 'Unexpected server error.',
+    };
+
+    for (const [err, msg] of Object.entries(serverErrorMap)) {
+      it(`handles ${err} error from server`, async () => {
+        (createWorry as any).mockRejectedValueOnce(new Error(err));
+
+        render(<CreateWorryForm />);
+
+        fillForm();
+
+        fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+        await waitFor(() => {
+          expect(notifications.show).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: 'Error',
+              message: msg,
+              color: 'red',
+            })
+          );
+        });
+      });
+    }
+
+    it('handles non-Error exceptions gracefully', async () => {
+      (createWorry as any).mockRejectedValueOnce('weird');
+
+      render(<CreateWorryForm />);
+      fillForm();
+
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(notifications.show).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Unexpected Error',
+            message: 'Unexpected server error. Please try again later.',
+            color: 'red',
+          })
+        );
+      });
+    });
+
+    it('fallbacks on unknown error code', async () => {
+      (createWorry as any).mockRejectedValueOnce(new Error('SOME_UNKNOWN_ERROR'));
+
+      render(<CreateWorryForm />);
+      fillForm();
+
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(notifications.show).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: 'Unexpected server error.',
+          })
+        );
+      });
+    });
+  });
+
+  describe('UI Rendering', () => {
+    it('renders all required fields', () => {
+      render(<CreateWorryForm />);
+
+      expect(screen.getByLabelText('Title')).toBeTruthy();
+      expect(screen.getByLabelText('Description')).toBeTruthy();
+    });
+
+    it('renders submit button', () => {
+      render(<CreateWorryForm />);
+
+      const btn = screen.getByRole('button', { name: /send/i }) as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+      expect(btn.type).toBe('submit');
+    });
+  });
+
+  describe('Loading Overlay', () => {
+    it('shows loading overlay while submitting', async () => {
+      let resolveSubmit: any;
+      const submitPromise = new Promise((resolve) => (resolveSubmit = resolve));
+      (createWorry as any).mockReturnValueOnce(submitPromise);
+
+      render(<CreateWorryForm />);
+      fillForm();
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-overlay')).toBeTruthy();
+      });
+
+      resolveSubmit();
+    });
+
+    it('hides loading overlay after submit completes', async () => {
+      let resolveSubmit: any;
+      const submitPromise = new Promise((resolve) => (resolveSubmit = resolve));
+      (createWorry as any).mockReturnValueOnce(submitPromise);
+
+      render(<CreateWorryForm />);
+      fillForm();
+      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading-overlay')).toBeTruthy();
+      });
+
+      resolveSubmit();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('loading-overlay')).toBeNull();
+      });
+    });
+  });
+
+  describe('Input Handling', () => {
+    it('updates title when user types', () => {
+      render(<CreateWorryForm />);
+      const input = screen.getByLabelText('Title') as HTMLInputElement;
+
+      fireEvent.change(input, { target: { value: 'abc' } });
+      expect(input.value).toBe('abc');
+    });
+
+    it('updates description when user types', () => {
+      render(<CreateWorryForm />);
+      const input = screen.getByLabelText('Description') as HTMLTextAreaElement;
+
+      fireEvent.change(input, { target: { value: 'xyz' } });
+      expect(input.value).toBe('xyz');
+    });
+  });
+});
+
+function fillForm() {
+  fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Worry Title' } });
+  fireEvent.change(screen.getByLabelText('Description'), {
+    target: { value: 'Something worrying' },
+  });
+}

--- a/app/protected/Resident/Create-Worry/tests/actions.test.tsx
+++ b/app/protected/Resident/Create-Worry/tests/actions.test.tsx
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createWorry } from '../actions';
+import { revalidatePath } from 'next/cache';
+
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+const mockFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+const mockSupabase = {
+  auth: {
+    getUser: mockGetUser,
+  },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+function makeForm(title: any, content: any) {
+  const fd = new FormData();
+  if (title !== undefined) fd.append('title', title);
+  if (content !== undefined) fd.append('content', content);
+  return fd;
+}
+
+function setupSelectChain() {
+  mockFrom.mockReturnValue({
+    select: mockSelect,
+  });
+
+  mockSelect.mockReturnValue({
+    eq: mockEq,
+  });
+
+  mockEq.mockReturnValue({
+    single: mockSingle,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockGetUser.mockReset();
+  mockFrom.mockReset();
+  mockSelect.mockReset();
+  mockEq.mockReset();
+  mockSingle.mockReset();
+
+  setupSelectChain();
+});
+
+describe('actions Create-Worry', () => {
+  it('throws ERROR_INVALID_TITLE if title is not a string', async () => {
+    const fd = makeForm(undefined as any, 'abc');
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_INVALID_TITLE');
+  });
+
+  it('throws ERROR_NO_TITLE when sanitized title is empty', async () => {
+    const fd = makeForm('   ', 'desc');
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_NO_TITLE');
+  });
+
+  it('throws ERROR_TITLE_TOO_LONG when title exceeds 120 chars', async () => {
+    const fd = makeForm('a'.repeat(121), 'Description');
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_TITLE_TOO_LONG');
+  });
+
+  it('throws ERROR_CONTENT_TOO_LONG when content exceeds 1200 chars', async () => {
+    const fd = makeForm('Title', 'a'.repeat(1201));
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_CONTENT_TOO_LONG');
+  });
+
+  it('sanitizes HTML from title and content before inserting', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle
+      .mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: insertMock,
+    });
+
+    const fd = makeForm('<b>Hello</b>', '<i>World</i>');
+
+    await createWorry(fd);
+
+    const inserted = insertMock.mock.calls[0][0];
+
+    expect(inserted.title).toBe('Hello');
+    expect(inserted.content).toBe('World');
+  });
+
+  it('trims whitespace from fields', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle
+      .mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: insertMock,
+    });
+
+    const fd = makeForm('   Title  ', '   Content   ');
+
+    await createWorry(fd);
+
+    const inserted = insertMock.mock.calls[0][0];
+
+    expect(inserted.title).toBe('Title');
+    expect(inserted.content).toBe('Content');
+  });
+
+  it('throws ERROR_UNAUTHORIZED when auth user is missing', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_UNAUTHORIZED');
+  });
+
+  it('throws ERROR_FETCHING_PROFILE when profile query fails', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'err' } });
+
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_FETCHING_PROFILE');
+  });
+
+  it('throws ERROR_USER_HAS_NO_COMMUNITY when community_id is null', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle.mockResolvedValueOnce({ data: { community_id: null }, error: null });
+
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_USER_HAS_NO_COMMUNITY');
+  });
+
+  it('throws ERROR_USER_HAS_NO_COMMUNITY when community_id is empty string', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle.mockResolvedValueOnce({ data: { community_id: '' }, error: null });
+
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_USER_HAS_NO_COMMUNITY');
+  });
+
+  it('throws ERROR_DB_INSERT_FAILED when insert fails', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle.mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: vi.fn().mockResolvedValue({ error: { message: 'failed' } }),
+    });
+
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_DB_INSERT_FAILED');
+  });
+
+  it('inserts into worries table with correct payload', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle
+      .mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: insertMock,
+    });
+
+    await createWorry(fd);
+
+    const call = insertMock.mock.calls[0][0];
+
+    expect(call).toEqual({
+      title: 'Valid',
+      content: 'Content',
+      created_by: 'u1',
+      community_id: 'c1',
+    });
+  });
+
+  it('calls revalidatePath after successful insert', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle
+      .mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    await createWorry(fd);
+
+    expect(revalidatePath).toHaveBeenCalledWith('/protected/Resident/Create-Worry');
+  });
+
+  it('queries users table correctly', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    mockSingle
+      .mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    await createWorry(fd);
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(mockSelect).toHaveBeenCalledWith('community_id');
+    expect(mockEq).toHaveBeenCalledWith('id', 'u1');
+  });
+
+  it('queries worries table on insert', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } } });
+
+    mockSingle
+      .mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: insertMock,
+    });
+
+    await createWorry(fd);
+
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'worries');
+    expect(insertMock).toHaveBeenCalledOnce();
+  });
+
+  it('wraps non Error exceptions into ERROR_UNKNOWN', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockImplementation(() => {
+      throw 'weird';
+    });
+
+    await expect(createWorry(fd)).rejects.toThrow('ERROR_UNKNOWN');
+  });
+
+  it('preserves native Error message when thrown', async () => {
+    const fd = makeForm('Valid', 'Content');
+
+    mockGetUser.mockRejectedValueOnce(new Error('CUSTOM_ERR'));
+
+    await expect(createWorry(fd)).rejects.toThrow('CUSTOM_ERR');
+  });
+
+  it('executes full successful flow', async () => {
+    const fd = makeForm('Hello', 'World');
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null });
+
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: { id: 'u1' } },
+    });
+
+    mockSingle
+      .mockResolvedValueOnce({ data: { community_id: 'c1' }, error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    });
+
+    mockFrom.mockReturnValueOnce({
+      insert: insertMock,
+    });
+
+    await expect(createWorry(fd)).resolves.not.toThrow();
+
+    expect(insertMock).toHaveBeenCalledOnce();
+    expect(revalidatePath).toHaveBeenCalled();
+  });
+});

--- a/app/protected/Resident/Create-Worry/tests/page.test.tsx
+++ b/app/protected/Resident/Create-Worry/tests/page.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CreateWorryPage from '../page';
+
+vi.mock('@mantine/core', async () => {
+  const actual = await vi.importActual<any>('@mantine/core');
+  return {
+    ...actual,
+    Flex: ({ children, ...props }: any) => (
+      <div data-testid="mantine-flex" {...props}>
+        {children}
+      </div>
+    ),
+    Card: ({ children }: any) => <div data-testid="card">{children}</div>,
+    Stack: ({ children }: any) => <div data-testid="stack">{children}</div>,
+    Group: ({ children }: any) => <div data-testid="group">{children}</div>,
+    Title: ({ children }: any) => <h2>{children}</h2>,
+    Text: ({ children }: any) => <span>{children}</span>,
+    TextInput: ({ label, value, onChange }: any) => (
+      <input aria-label={label} value={value ?? ''} onChange={onChange} />
+    ),
+    Textarea: ({ label, value, onChange }: any) => (
+      <textarea aria-label={label} value={value ?? ''} onChange={onChange} />
+    ),
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    LoadingOverlay: ({ visible }: any) => (visible ? <div data-testid="loading-overlay" /> : null),
+  };
+});
+
+vi.mock('../components/CreateWorryForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="create-worry-form" />,
+}));
+
+describe('CreateWorryPage', () => {
+  it('renders without crashing', () => {
+    render(<CreateWorryPage />);
+    expect(screen.getByTestId('mantine-flex')).toBeTruthy();
+  });
+
+  it('includes the CreateWorryForm component', () => {
+    render(<CreateWorryPage />);
+    expect(screen.getByTestId('create-worry-form')).toBeTruthy();
+  });
+
+  it('applies correct Flex props', () => {
+    render(<CreateWorryPage />);
+    const flex = screen.getByTestId('mantine-flex');
+
+    expect(flex.getAttribute('justify')).toBe('center');
+    expect(flex.style.paddingTop).toBe('3rem');
+  });
+});


### PR DESCRIPTION
Closes #149

- Added unit testing for Create-Worry page, and all related files to it