### PR TITLE
fix(notices): correct like count syncing for admin and resident views

### DIFF
--- a/app/protected/Admin/Notices/actions.ts
+++ b/app/protected/Admin/Notices/actions.ts
@@ -7,7 +7,7 @@ import type { Notice } from '@/types/Notice';
 
 export async function getNotices(
   page = 1,
-  limit = 1, // 
+  limit = 3, // this we can change :)
   category?: string,
   sort: 'newest' | 'oldest' = 'newest'
 ): Promise<{ data: Notice[]; count: number }> {
@@ -28,9 +28,24 @@ export async function getNotices(
     const from = (page - 1) * limit;
     const to = from + limit - 1;
 
+    //  include likesnotice  so admin can see number of likes
     let query = supabase
       .from('notices')
-      .select('id, title, content, category, community_id, created_at', { count: 'exact' })
+      .select(
+        `
+        id,
+        title,
+        content,
+        category,
+        community_id,
+        created_at,
+        likesnotice (
+          id,
+          user_id
+        )
+      `,
+        { count: 'exact' }
+      )
       .eq('community_id', profile.community_id);
 
     if (category && category !== '') {
@@ -42,9 +57,23 @@ export async function getNotices(
     const { data, count, error } = await query.range(from, to);
     if (error) throw error;
 
-    return { data: data ?? [], count: count ?? 0 };
+    // map likes into likesCount (admin doesn’t need hasLiked)
+    const notices: Notice[] =
+      (data ?? []).map((row: any) => {
+        const likes = row.likesnotice ?? [];
+        const likesCount = likes.length;
+
+        const { likesnotice, ...rest } = row;
+        return {
+          ...rest,
+          likesCount,
+        } as Notice;
+      });
+
+    return { data: notices, count: count ?? 0 };
   } catch (err) {
-    throw err;
+    console.error('Error fetching admin notices:', err);
+    return { data: [], count: 0 };
   }
 }
 
@@ -72,14 +101,19 @@ export async function getMeetings(): Promise<Meeting[]> {
     if (error) throw error;
     return data ?? [];
   } catch (err) {
-    throw err;
+    console.error('Error fetching admin meetings:', err);
+    return [];
   }
 }
 
-export async function updateNotice(id: string, values: { title: string; content: string; category: string }) {
+export async function updateNotice(
+  id: string,
+  values: { title: string; content: string; category: string }
+) {
   const supabase = await createClient();
   const { data: auth } = await supabase.auth.getUser();
   if (!auth?.user) throw new Error('ERROR_UNAUTHORIZED_USER');
+
   const { data: profile } = await supabase
     .from('users')
     .select('community_id')
@@ -105,6 +139,7 @@ export async function updateMeeting(
   const supabase = await createClient();
   const { data: auth } = await supabase.auth.getUser();
   if (!auth?.user) throw new Error('ERROR_UNAUTHORIZED_USER');
+
   const { data: profile } = await supabase
     .from('users')
     .select('community_id')
@@ -127,6 +162,7 @@ export async function deleteNotice(id: string) {
   const supabase = await createClient();
   const { data: auth } = await supabase.auth.getUser();
   if (!auth?.user) throw new Error('ERROR_UNAUTHORIZED_USER');
+
   const { data: profile } = await supabase
     .from('users')
     .select('community_id')
@@ -149,6 +185,7 @@ export async function deleteMeeting(id: string) {
   const supabase = await createClient();
   const { data: auth } = await supabase.auth.getUser();
   if (!auth?.user) throw new Error('ERROR_UNAUTHORIZED_USER');
+
   const { data: profile } = await supabase
     .from('users')
     .select('community_id')


### PR DESCRIPTION
Ensure that when a resident likes a notice, the admin panel properly loads and displays updated like counts. Updated Admin Notices query to include likesrelation and map likesCount the same way as in Resident view.

closes #138