### PR TITLE
feat(ui): add delete confirmation modal for worries and residents

### DIFF
--- a/app/protected/Admin/Residents/components/DeleteResidentButton.tsx
+++ b/app/protected/Admin/Residents/components/DeleteResidentButton.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import ConfirmModal from '@/components/ui/ConfirmModal';
+import { removeResidentAction } from '../actions';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  id: string;
+  mode: 'reject' | 'remove';
+  onDone?: () => void;
+}
+
+export default function DeleteResidentButton({ id, mode, onDone }: Props) {
+  const [opened, setOpened] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const title = mode === 'reject' ? 'Reject resident' : 'Remove resident';
+  const message =
+    mode === 'reject'
+      ? 'Are you sure you want to reject this resident request? This will remove the user from the community.'
+      : 'Are you sure you want to remove this resident? This will delete the user and their worries.';
+
+  const buttonLabel = mode === 'reject' ? 'Reject' : 'Remove';
+
+  const handleConfirm = () => {
+    startTransition(async () => {
+      await removeResidentAction(id);
+      onDone?.();
+      setOpened(false);
+    });
+  };
+
+  return (
+    <>
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={() => setOpened(true)}
+        disabled={isPending}
+      >
+        {isPending ? `${buttonLabel}…` : buttonLabel}
+      </Button>
+
+      <ConfirmModal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        onConfirm={handleConfirm}
+        loading={isPending}
+        title={title}
+        message={message}
+      />
+    </>
+  );
+}

--- a/app/protected/Admin/Residents/page.tsx
+++ b/app/protected/Admin/Residents/page.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { createClient } from '@/lib/supabase/client';
 import { getResidents, removeResidentAction, type AdminResident } from './actions';
+import DeleteResidentButton from './components/DeleteResidentButton';
 
 const supabase = createClient();
 
@@ -29,7 +30,6 @@ export default function AdminResidentsPage() {
       setLoading(true);
 
       try {
-        // ✅ Now filtered by admin's community in server action
         const { data } = await getResidents(1, 200, 'newest');
         setUsers(data);
       } catch (err) {
@@ -52,22 +52,6 @@ export default function AdminResidentsPage() {
       console.error('Error updating user status:', error.message);
     } else {
       setUsers((prev) => prev.map((user) => (user.id === id ? { ...user, status } : user)));
-    }
-
-    setUpdatingId(null);
-  };
-
-  const removeResident = async (id: string) => {
-    const confirmed = window.confirm('Are you sure you want to remove this resident?');
-    if (!confirmed) return;
-
-    setUpdatingId(id);
-
-    try {
-      await removeResidentAction(id);
-      setUsers((prev) => prev.filter((u) => u.id !== id));
-    } catch (err) {
-      console.error(err);
     }
 
     setUpdatingId(null);
@@ -140,14 +124,13 @@ export default function AdminResidentsPage() {
                     Approve
                   </Button>
 
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => removeResident(user.id)}
-                    disabled={updatingId === user.id}
-                  >
-                    Reject
-                  </Button>
+                  <DeleteResidentButton
+                    id={user.id}
+                    mode="reject"
+                    onDone={() =>
+                      setUsers((prev) => prev.filter((u) => u.id !== user.id))
+                    }
+                  />
                 </Group>
               </Group>
             </Card>
@@ -198,14 +181,13 @@ export default function AdminResidentsPage() {
                   </Stack>
                 </Group>
 
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => removeResident(user.id)}
-                  disabled={updatingId === user.id}
-                >
-                  {updatingId === user.id ? 'Removing…' : 'Remove'}
-                </Button>
+                <DeleteResidentButton
+                  id={user.id}
+                  mode="remove"
+                  onDone={() =>
+                    setUsers((prev) => prev.filter((u) => u.id !== user.id))
+                  }
+                />
               </Group>
             </Card>
           ))}

--- a/app/protected/Admin/Worries/components/DeleteButtonWorry.tsx
+++ b/app/protected/Admin/Worries/components/DeleteButtonWorry.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Button } from '@mantine/core';
+import { Trash } from 'lucide-react';
+import ConfirmModal from '@/components/ui/ConfirmModal';
+import { deleteWorry } from '@/app/protected/Admin/Worries/actions';
+
+interface Props {
+  id: string;
+  onDeleted?: () => void; // callback after successful delete
+}
+
+export default function DeleteButtonWorry({ id, onDeleted }: Props) {
+  const [opened, setOpened] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const handleConfirm = () => {
+    startTransition(async () => {
+      await deleteWorry(id);
+      onDeleted?.();
+      setOpened(false);
+    });
+  };
+
+  return (
+    <>
+      <Button
+        variant="light"
+        color="red"
+        radius="xl"
+        size="compact-sm"
+        leftSection={<Trash size={14} />}
+        onClick={() => setOpened(true)}
+        disabled={isPending}
+      >
+        {isPending ? 'Deleting…' : 'Delete'}
+      </Button>
+
+      <ConfirmModal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        onConfirm={handleConfirm}
+        loading={isPending}
+        title="Delete worry"
+        message="Are you sure you want to delete this worry?"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Replaced default browser dialogs with reusable ConfirmModal. Applied to:
- Worries: delete action
- Residents: reject (pending) and remove (approved)

closes #139